### PR TITLE
sim: use depend option in all simulators

### DIFF
--- a/fusesoc/core.py
+++ b/fusesoc/core.py
@@ -43,12 +43,10 @@ class Core:
             #FIXME : Make simulators part of the core object
             self.simulator        = config.get_section('simulator')
             self.icarus           = config.get_section('icarus')
+            self.modelsim         = config.get_section('modelsim')
+            self.verilator        = config.get_section('verilator')
             self.pre_run_scripts  = config.get_list('scripts','pre_run_scripts')
             self.post_run_scripts = config.get_list('scripts','post_run_scripts')
-
-            self.vlog_options     = config.get_list('modelsim','vlog_options')
-            self.vsim_options     = config.get_list('modelsim','vsim_options')
-            self.verilator = config.get_section('verilator')
 
             logger.debug('name=' + str(self.name))
             self.core_root = os.path.dirname(core_file)

--- a/fusesoc/simulator/verilator.py
+++ b/fusesoc/simulator/verilator.py
@@ -51,6 +51,8 @@ class Verilator(Simulator):
                 self.src_type = items.get(item)
             elif item == 'define_files':
                 self.define_files = items.get(item).split()
+            elif item == 'depend':
+                self.cores = items.get(item).split()
             else:
                 print("Warning: Unknown item '" + item +"' in verilator section")
 


### PR DESCRIPTION
A previous commit introduced "depend" for cores to be fetched
only when a specific simulator is used. This commit added this
option to Icarus only.

This patch add "depend" to Modelsim and Verilator.

It also change the way options are handled by Modelsim.
It is now done the same way Icarus and Verilator do it.

Signed-off-by: Franck Jullien franck.jullien@gmail.com
