### PR TITLE
verilator: add top_module parameter

### DIFF
--- a/bin/fusesoc.in
+++ b/bin/fusesoc.in
@@ -17,7 +17,7 @@ from fusesoc.coremanager import CoreManager, DependencyError
 from fusesoc.simulator import SimulatorFactory
 from fusesoc.simulator.verilator import Source
 from fusesoc.system import System
-from fusesoc.core import Core
+from fusesoc.core import Core, OptionSectionMissing
 import logging
 
 logging.basicConfig(filename='fusesoc.log', filemode='w', level=logging.DEBUG)
@@ -127,6 +127,9 @@ def sim(known, remaining):
         sim = SimulatorFactory(sim_name, core)
     except DependencyError as e:
         print("Error: '" + known.system + "' or any of its dependencies requires '" + e.value + "', but this core was not found")
+        exit(1)
+    except OptionSectionMissing as e:
+        print("Error: '" + known.system + "' miss a mandatory parameter for " + sim_name + " simulation (" + e.value + ").")
         exit(1)
     if known.force or not os.path.exists(sim.sim_root):
         sim.configure()

--- a/doc/capi.txt
+++ b/doc/capi.txt
@@ -82,6 +82,7 @@ converted to #define directives in corresponding .h files
 * *include_files (optional)     :* List of C or SystemC include files
 * *tb_toplevel (optional)       :* Name of the test bench top file
 * *depend (optional)            :* List of cores that only Verilator simulation depends on
+* *top_module (optional)        :* Name of the verilog top module
 
 verilog
 ~~~~~~~

--- a/fusesoc/core.py
+++ b/fusesoc/core.py
@@ -12,6 +12,12 @@ import logging
 
 logger = logging.getLogger(__name__)
 
+class OptionSectionMissing(Exception):
+    def __init__(self, value):
+        self.value = value
+    def __str__(self):
+        return repr(self.value)
+
 class Core:
     def __init__(self, core_file=None, name=None, core_root=None):
         logger.debug('__init__() *Entered*' +


### PR DESCRIPTION
This patch adds top_module parameter to the verilator
CAPI section. This parameter is mandatory for the
system core.

It also make tb_toplevel not optional.

Signed-off-by: Franck Jullien franck.jullien@gmail.com
