### PR TITLE
verilator: fix src_type defaulting to 'C'

### DIFF
--- a/bin/fusesoc.in
+++ b/bin/fusesoc.in
@@ -133,7 +133,7 @@ def sim(known, remaining):
         try:
             sim.build()
         except Source as e:
-            print( e.value + " Source type don't valid. choose: C or systemC")
+            print( "'" + e.value + "' source type is not valid. Choose 'C' or 'systemC'.")
             exit(1)
         except RuntimeError as e:
             print("Error: Failed to build simulation model. " + str(e))

--- a/fusesoc/simulator/verilator.py
+++ b/fusesoc/simulator/verilator.py
@@ -23,7 +23,7 @@ class Verilator(Simulator):
         self.include_files = []
         self.include_dirs = []
         self.tb_toplevel = ""
-        self.src_type = 'C'
+        self.src_type = ''
         self.define_files = []
         self.libs = []
 
@@ -119,7 +119,7 @@ class Verilator(Simulator):
     def build(self):
         super(Verilator, self).build()
         self._verilate()
-        if self.src_type == 'C':
+        if self.src_type == 'C' or self.src_type == '':
             self.build_C()
         elif self.src_type == 'systemC':
             self.build_SysC()


### PR DESCRIPTION
After the sections refactoring, verilator lost its
ability to default src_type to 'C'. This patch brings
back this feature.

It also changes the associated error message syntax.

Signed-off-by: Franck Jullien franck.jullien@gmail.com
