### PR TITLE
coremanager: allow sub-directories in cores/systems

### DIFF
--- a/fusesoc/coremanager.py
+++ b/fusesoc/coremanager.py
@@ -45,7 +45,13 @@ class CoreManager(object):
             raise IOError(path + " is not a directory")
         for d in os.listdir(path):
             f = os.path.join(path, d, d+'.core')
-            self.load_core(d, f)
+            if os.path.isfile(f) == False:
+                core_dir = os.path.join(path, d)
+                for core_subdir in os.listdir(core_dir):
+                    subcore = os.path.join(core_dir, core_subdir, core_subdir+'.core')
+                    self.load_core(core_subdir, subcore)
+            else:
+                self.load_core(d, f)
 
     def add_cores_root(self, path):
         if path is None:


### PR DESCRIPTION
With this new features, we can have multiples sub-directories
in systems and cores directories. For example:

|
|
|
|
|

This allows systems to be grouped under board name.

Signed-off-by: Franck Jullien franck.jullien@gmail.com
