### PR TITLE
VerilatorSection: add export() method

### DIFF
--- a/fusesoc/core.py
+++ b/fusesoc/core.py
@@ -123,6 +123,8 @@ class Core:
             src_files += self.verilog.export()
         if self.vpi:
             src_files += self.vpi.export()
+        if self.verilator:
+            src_files += self.verilator.export()
 
         dirs = list(set(map(os.path.dirname,src_files)))
         logger.debug("export src_files=" + str(src_files))

--- a/fusesoc/section/__init__.py
+++ b/fusesoc/section/__init__.py
@@ -115,6 +115,9 @@ Verilog top module      : {top_module}
                         source_type=self.source_type,
                         top_module=self.top_module)
 
+    def export(self):
+        return list(self.src_files) + list(self.include_files)
+
     def build(self, core, sim_root, src_root):
         if self.source_type == 'C' or self.source_type == '':
             self.build_C(core, sim_root, src_root)


### PR DESCRIPTION
This add an export() method to VerilatorSection, with the purpose
of exporting a list of files to be used in core.py.
core.py is also updated to make use of this method.
