### PR TITLE
quartus: add support for qsys generation

### DIFF
--- a/doc/sapi.txt
+++ b/doc/sapi.txt
@@ -47,6 +47,8 @@ Additional options used when building with Quartus:
 * *device    :* Altera device name (e.g. EP2C20F484C7).
 * *sdc_files :* List of SDC files used by Quartus.
 * *tcl_files :* List of TCL files. Files content is included in the Quartus Setting File (.qsf).
+* *qsys_files:* List of qsys files (optional). Qsys will be executed on
+                each of the files present in this list.
 
 scripts (optional)
 ~~~~~~~~~~~~~~~~~~

--- a/fusesoc/build/quartus.py
+++ b/fusesoc/build/quartus.py
@@ -35,10 +35,68 @@ clean:
         self.work_root = os.path.join(self.build_root, 'bld-'+self.TOOL_NAME)
 
     def configure(self):
-
         super(Quartus, self).configure()
+        self._run_qsys()
         self._write_tcl_file()
         self._write_makefile()
+
+    # Runs qsys if a 'qsys_files' entry can be found under the quartus section
+    def _run_qsys(self):
+        self.qip_files = []
+        if not 'qsys_files' in self.system.backend:
+            return
+
+        qsys_script = open(os.path.join(self.work_root, 'qsys.sh'),'w')
+
+        for f in self.system.backend['qsys_files'].split():
+            src_file = os.path.join(self.systems_root, self.system.name, f)
+            dst_file = os.path.join(self.work_root, f)
+            dst_dir = os.path.dirname(dst_file)
+            if not os.path.exists(dst_dir):
+                os.makedirs(dst_dir)
+            shutil.copyfile(src_file, dst_file)
+
+            args = []
+            args += ['--project-directory=' + dst_dir]
+            args += ['--output-directory=' +
+                     os.path.join(self.build_root, 'src/qsys')]
+            args += ['--report-file=bsf:' +
+                     os.path.join(dst_dir, self.system.name+'.bsf')]
+            args += ['--system-info=DEVICE_FAMILY=' +
+                     self.system.backend['family']]
+            args += ['--system-info=DEVICE=' +
+                     self.system.backend['device']]
+            args += ['--component-file=' + dst_file]
+
+            qsys_script.write('ip-generate ' + ' '.join(args) + '\n');
+
+            self.qip_files += [os.path.join(self.build_root,
+                                            'src/qsys/synthesis',
+                                            self.system.name+'.qip')]
+            args = []
+            args += ['--project-directory=' + dst_dir]
+            args += ['--output-directory=' +
+                     os.path.join(self.build_root, 'src/qsys/synthesis')]
+            args += ['--file-set=QUARTUS_SYNTH']
+            args += ['--report-file=sopcinfo:' +
+                     os.path.join(dst_dir, self.system.name+'.sopcinfo')]
+            args += ['--report-file=html:' +
+                     os.path.join(dst_dir, self.system.name+'.html')]
+            args += ['--report-file=qip:' + self.qip_files[-1]]
+            args += ['--report-file=cmp:' +
+                     os.path.join(dst_dir, self.system.name+'.cmp')]
+            args += ['--report-file=svd']
+            args += ['--system-info=DEVICE_FAMILY=' +
+                     self.system.backend['family']]
+            args += ['--system-info=DEVICE=' +
+                     self.system.backend['device']]
+            args += ['--component-file=' + dst_file]
+            args += ['--language=VERILOG']
+
+            qsys_script.write('ip-generate ' + ' '.join(args) + '\n');
+
+        qsys_script.close()
+        subprocess.call(['sh', os.path.join(self.work_root, 'qsys.sh')]);
 
     def _write_tcl_file(self):
         tcl_file = open(os.path.join(self.work_root, self.system.name+'.tcl'),'w')
@@ -53,7 +111,6 @@ clean:
 
         #FIXME: Handle multiple SDC files. Also handle SDC files directly from cores?
         sdc_files = self.system.backend['sdc_files'].split()
-
         for f in sdc_files:
             src_file = os.path.join(self.systems_root, self.system.name, f)
             dst_file =os.path.join(self.work_root, f)
@@ -61,6 +118,13 @@ clean:
                 os.makedirs(os.path.dirname(dst_file))
             shutil.copyfile(src_file, dst_file)
             tcl_file.write("set_global_assignment -name SDC_FILE " + dst_file + '\n')
+
+        # NOTE: The relative path _have_ to be used here, if the absolute path
+        # is used, quartus_asm will fail with an error message that
+        # sdram_io.pre.h can't be read or written.
+        for f in self.qip_files:
+            tcl_file.write("set_global_assignment -name QIP_FILE " +
+                           os.path.relpath(f, self.work_root) + '\n')
 
         tcl_files = self.system.backend['tcl_files'].split()
         for f in tcl_files:


### PR DESCRIPTION
When the (new) 'qsys_files' entry under the 'quartus' section is
present, a shell script is created with the necessary commands
generate a system described in a .qsys file.
The approach with first creating a shell script and then
executing that, instead of executing the commands directly from
fusesoc was chosen to keep the build directory still completely
independent from fusesoc once generated.
