### PR TITLE
VerilatorSection: define self.export_files

### DIFF
--- a/fusesoc/core.py
+++ b/fusesoc/core.py
@@ -123,6 +123,8 @@ class Core:
             src_files += self.verilog.export()
         if self.vpi:
             src_files += self.vpi.export()
+        if self.verilator:
+            src_files += self.verilator.export()
 
         dirs = list(set(map(os.path.dirname,src_files)))
         logger.debug("export src_files=" + str(src_files))

--- a/fusesoc/section/__init__.py
+++ b/fusesoc/section/__init__.py
@@ -95,6 +95,7 @@ class VerilatorSection(ToolSection):
             if self.src_files:
                 self._object_files = [os.path.splitext(os.path.basename(s))[0]+'.o' for s in self.src_files]
                 self.archive = True
+        self.export_files = self.src_files + self.include_files
 
     def __str__(self):
         s = """Verilator options       : {verilator_options}


### PR DESCRIPTION
This defines self.export_files, which is used by the export()
method in the Section class.
core.py is also updated to make use of this method.
