### PR TITLE
quartus: make top module name configurable

### DIFF
--- a/doc/sapi.txt
+++ b/doc/sapi.txt
@@ -45,6 +45,7 @@ Additional options used when building with Quartus:
 
 * *family    :* Altera device family name (e.g. "Cyclone II").
 * *device    :* Altera device name (e.g. EP2C20F484C7).
+* *top_module:* Project top module name
 * *sdc_files :* List of SDC files used by Quartus.
 * *tcl_files :* List of TCL files. Files content is included in the Quartus Setting File (.qsf).
 

--- a/fusesoc/build/quartus.py
+++ b/fusesoc/build/quartus.py
@@ -45,7 +45,11 @@ clean:
         tcl_file.write("project_new " + self.system.name + " -overwrite\n")
         tcl_file.write("set_global_assignment -name FAMILY " + self.system.backend['family'] + '\n')
         tcl_file.write("set_global_assignment -name DEVICE " + self.system.backend['device'] + '\n')
-        tcl_file.write("set_global_assignment -name TOP_LEVEL_ENTITY " + "orpsoc_top" + '\n')
+        # default to 'orpsoc_top' if top_module entry is missing
+        top_module = 'orpsoc_top'
+        if 'top_module' in self.system.backend:
+            top_module = self.system.backend['top_module']
+        tcl_file.write("set_global_assignment -name TOP_LEVEL_ENTITY " + top_module + '\n')
         for src_file in self.src_files:
             tcl_file.write("set_global_assignment -name VERILOG_FILE " + src_file + '\n')
         for include_dir in self.include_dirs:


### PR DESCRIPTION
A 'top_module' entry is added to the quartus section.
To keep compatibility with old cores, it falls back to
orpsoc_top.
