### PR TITLE
utils: make get_verilator_root work with python3

### DIFF
--- a/fusesoc/utils.py
+++ b/fusesoc/utils.py
@@ -69,7 +69,7 @@ def get_verilator_root():
     if verilator is None:
         return None
     output = subprocess.check_output(verilator + ' -V',
-                                     shell=True).splitlines();
+                                     shell=True).decode().splitlines()
     pattern = re.compile("VERILATOR_ROOT")
     for l in output:
         if pattern.search(l):


### PR DESCRIPTION
str and byte string handling in python2.7 and python3.x differ
a lot, doing str type of operations on a byte string in python3
doesn't fly.
To fix this, decode the byte string into a str before doing
operations on it.

This is a replacement to https://github.com/olofk/fusesoc/pull/39
and contains the fix I propose there, and as Franck suggests there,
I'm preparing the patch for it with a proper commit message here.
