### PR TITLE
add simple bash-completion script for fusesoc

### DIFF
--- a/bash-completion/fusesoc
+++ b/bash-completion/fusesoc
@@ -1,0 +1,30 @@
+# fusesoc completion                                      -*- shell-script -*-
+
+_fusesoc()
+{
+    local cur prev words cword
+    _init_completion || return
+
+    COMPREPLY=()
+
+    case $prev in
+	system-info)
+	    COMPREPLY=( $( compgen -W "$( $1 list-systems |
+		grep -v 'Available systems' )" -- $cur ) )
+	    ;;
+	build|sim|pgm|fetch|core-info)
+	    COMPREPLY=( $( compgen -W "$( $1 list-cores | awk 'NR > 5' |
+		awk '{print $1}' )" -- $cur ) )
+	    ;;
+    esac
+
+    if [[ $cword -eq 1 ]]; then
+	COMPREPLY=( $( compgen -W 'build pgm fetch list-systems system-info
+		list-cores core-info sim' -- "$cur" ) )
+    fi
+    return 0
+
+} &&
+complete -F _fusesoc fusesoc
+
+# ex: ts=4 sw=4 et filetype=sh


### PR DESCRIPTION
Only the most basic commands are handled, but at least
it fetches the available cores/systems and allows for
autocompletion amongst them.

Further improvements would be to recognize sub-options.
(for instance, the common --elf-load should be easy to
implement as a file completion)
