### PR TITLE
Add support for 'git submodule' provider

### DIFF
--- a/fusesoc/provider/github.py
+++ b/fusesoc/provider/github.py
@@ -10,7 +10,7 @@ else:
     import urllib
 
 class GitHub(object):
-    def __init__(self, config):
+    def __init__(self, core_name, config, core_root, cache_root):
         self.user   = config.get('user')
         self.repo   = config.get('repo')
         self.branch = config.get('branch')
@@ -18,15 +18,16 @@ class GitHub(object):
             self.version = config.get('version')
         else:
             self.version = 'master'
+        self.files_root = cache_root
 
-    def fetch(self, local_dir, core_name):
-        status = self.status(local_dir)
+    def fetch(self):
+        status = self.status()
         if status == 'empty':
-            self._checkout(local_dir)
+            self._checkout(self.files_root)
             return True
         elif status == 'modified':
             self.clean_cache()
-            self._checkout(local_dir)
+            self._checkout(self.files_root)
             return True
         elif status == 'outofdate':
             self._update()
@@ -36,7 +37,7 @@ class GitHub(object):
         else:
             pr_warn("Provider status is: '" + status + "'. This shouldn't happen")
             return False
-            #TODO: throw an exception here 
+            #TODO: throw an exception here
 
     def _checkout(self, local_dir):
         #TODO : Sanitize URL
@@ -53,8 +54,8 @@ class GitHub(object):
         os.rename(os.path.join(cache_root, tmp),
                   os.path.join(cache_root, core))
 
-    def status(self, local_dir):
-        if not os.path.isdir(local_dir):
+    def status(self):
+        if not os.path.isdir(self.files_root):
             return 'empty'
         else:
             return 'downloaded'

--- a/fusesoc/provider/opencores.py
+++ b/fusesoc/provider/opencores.py
@@ -6,25 +6,26 @@ import logging
 logger = logging.getLogger(__name__)
 
 class ProviderOpenCores(object):
-    def __init__(self, config):
+    def __init__(self, core_name, config, core_root, cache_root):
         self.repo_path = 'http://opencores.org/ocsvn/' + \
             config.get('repo_name') + '/' + config.get('repo_name') + '/' + \
             config.get('repo_root')
         self.revision_number  = config.get('revision')
+        self.files_root = cache_root
 
-    def fetch(self, local_dir, core_name):
-        status = self.status(local_dir)
+    def fetch(self):
+        status = self.status()
 
         if status == 'empty':
             try:
-                self._checkout(local_dir)
+                self._checkout(self.files_root)
                 return True
             except RuntimeError:
                 raise
         elif status == 'modified':
             self.clean_cache()
             try:
-                self._checkout(local_dir)
+                self._checkout(self.files_root)
                 return True
             except RuntimeError:
                 raise
@@ -37,13 +38,13 @@ class ProviderOpenCores(object):
             pr_warn("Provider status is: '" + status + "'. This shouldn't happen")
             return False
 
-    def status(self, local_dir):
+    def status(self):
         #FIXME: Check if repo is modified, or is an SVN repo at all, etc..
-        if not os.path.isdir(local_dir):
+        if not os.path.isdir(self.files_root):
             return 'empty'
         else:
             return 'downloaded'
-        
+
     def _checkout(self, local_dir):
         pr_info("Checking out " + self.repo_path + " revision " + self.revision_number + " to " + local_dir)
 

--- a/fusesoc/provider/submodule.py
+++ b/fusesoc/provider/submodule.py
@@ -1,0 +1,28 @@
+import subprocess
+import os
+
+class Submodule(object):
+    def __init__(self, core_name, config, core_root, cache_root):
+        self.repo = config.get('repo')
+        self.core_root = core_root
+        self.submodule_path = os.path.join(self.core_root, self.repo)
+        self.marker = os.path.join(self.submodule_path, '.git')
+        self.files_root = self.submodule_path
+
+    def fetch(self):
+        status = self.status()
+        if status != 'downloaded':
+            self._checkout()
+        return True
+
+    def _checkout(self):
+        pwd = os.getcwd()
+        os.chdir(self.core_root)
+        subprocess.check_call(['git', 'submodule', 'update', '--init',
+            '--remote', '--checkout', self.repo])
+        os.chdir(pwd)
+
+    def status(self):
+        return 'downloaded' if os.path.isfile(self.marker) else 'empty'
+
+PROVIDER_CLASS = Submodule

--- a/fusesoc/provider/url.py
+++ b/fusesoc/provider/url.py
@@ -15,31 +15,27 @@ else:
     import urllib
 
 class ProviderURL(object):
-    def __init__(self, config):
+    def __init__(self, core_name, config, core_root, cache_root):
         self.url      = config.get('url')
         self.filetype = config.get('filetype')
         if 'corename' in config:
             self.version = config.get('corename')
         else:
-            self.version = '----'
+            self.version = core_name
+        self.files_root = cache_root
 
-    def fetch(self, local_dir, core_name):
-        status = self.status(local_dir)
-        if '----' in self.version:
-            self.corename = core_name
-        else:
-            self.corename = self.version
-
+    def fetch(self):
+        status = self.status()
         if status == 'empty':
             try:
-                self._checkout(local_dir, self.corename)
+                self._checkout(self.files_root, self.version)
                 return True
             except RuntimeError:
                 raise
         elif status == 'modified':
             self.clean_cache()
             try:
-                self._checkout(local_dir, self.corename)
+                self._checkout(self.files_root, self.version)
                 return True
             except RuntimeError:
                 raise
@@ -78,8 +74,8 @@ class ProviderURL(object):
             raise RuntimeError("Unknown file type '" + self.filetype + "' in [provider] section")
 
 
-    def status(self, local_dir):
-        if not os.path.isdir(local_dir):
+    def status(self):
+        if not os.path.isdir(self.files_root):
             return 'empty'
         else:
             return 'downloaded'


### PR DESCRIPTION
This adds support for using git submodules as a provider.
This provider does not use the cache directory but checks out the
repository inside of core directory. On fetch the latest version from
the remote is used.
