### PR TITLE
sim/verilator: check for SYSTEMC_INCLUDE and SYSTEMC_LIBDIR

### DIFF
--- a/fusesoc/simulator/verilator.py
+++ b/fusesoc/simulator/verilator.py
@@ -110,6 +110,10 @@ class Verilator(Simulator):
         if cmd is None:
              raise RuntimeError("VERILATOR_ROOT not set and there is no verilator program in your PATH")
         cmd += ' ' + ' '.join(args)
+
+        if utils.check_systemc_env() is False:
+            raise RuntimeError("Need $SYSTEMC_LIBDIR and $SYSTEMC_INCLUDE in environment or when Verilator configured")
+
         l = utils.Launcher(cmd,
                            shell=True,
                            cwd = self.sim_root,

--- a/fusesoc/utils.py
+++ b/fusesoc/utils.py
@@ -85,6 +85,31 @@ def get_verilator_root():
 
     return None
 
+def check_systemc_env():
+    systemc_include = os.getenv('SYSTEMC_INCLUDE')
+    systemc_libdir = os.getenv('SYSTEMC_LIBDIR')
+    if systemc_include is not None and systemc_libdir is not None:
+        return True
+
+    # SYSTEMC_INCLUDE and/or  SYSTEMC_LIBDIR not set, run 'verilator -V'
+    # and 'grep' the hardcoded value out of the output.
+    verilator = find_verilator()
+    if verilator is None:
+        return False
+    output = subprocess.check_output(verilator + ' -V',
+                                     shell=True).decode().splitlines()
+
+    pattern = re.compile("SYSTEMC_LIBDIR")
+    for l in output:
+        if pattern.search(l):
+            systemc_libdir = l.split('=')[1].strip()
+
+    pattern = re.compile("SYSTEMC_INCLUDE")
+    for l in output:
+        if pattern.search(l):
+            systemc_include = l.split('=')[1].strip()
+
+    return os.path.isdir(systemc_libdir) is True and os.path.isdir(systemc_include) is True
 
 #Copied from http://twistedmatrix.com/trac/browser/tags/releases/twisted-8.2.0/twisted/python/procutils.py
 


### PR DESCRIPTION
Before we use SystemC, we should check for SYSTEMC_INCLUDE
and SYSTEMC_LIBDIR environment variable so we don't have
to read the log file to see what was wrong.

Those two values can be set in verilator at compile time.

Signed-off-by: Franck Jullien franck.jullien@gmail.com
