### PR TITLE
Use setuptools for the installation

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -1,20 +1,22 @@
 FuseSoC can be run directly from a downloaded tarball release or from a
-checked out repository. In these cases the main program is available as
-bin/fusesoc.in. This is handy if you want to work on FuseSoC itself.
+checked out repository, or installed from the Python Package Index via pip.
 
 Unless you want to do development on FuseSoC itself, it is better to do a system
 installation. Follow these steps to do a system-wide installation.
 
-(If you install FuseSoC from from a GIT repository instead of using a released
-tarball, you first need to run "autoreconf -i").
+Install from PyPI:
 
-If your system uses an incompatible version of Python (i.e. < 2.7) or if
-you want to use a specific version of Python, you need to set an environment
-variable, $PYTHON, to point to where the Python binary is.
+    sudo pip install fusesoc
 
-Run "./configure && make" to build FuseSoC.
-Install it with "make install" and make sure you have write permissions to the
-target directory.
+Install from git checkout:
+
+    sudo python setup.py install
+
+Install using autotools:
+
+    autoreconf -i
+    ./configure && make
+    make install
 
 You most certainly want the default collection of cores to get started as well.
 These are currently hosted at github.com/openrisc/orpsoc-cores. Download the

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include readme.md

--- a/bin/fusesoc
+++ b/bin/fusesoc
@@ -19,8 +19,6 @@ else:
 fusesocdir = os.path.abspath(os.path.join(os.path.dirname(os.path.realpath(__file__)), ".."))
 if os.path.exists(os.path.join(fusesocdir, "fusesoc")):
     sys.path[0:0] = [fusesocdir]
-else:
-    sys.path[0:0] = ['@pythondir@']
 
 from fusesoc.build import BackendFactory
 from fusesoc.config import Config

--- a/readme.md
+++ b/readme.md
@@ -21,10 +21,10 @@ FuseSoC does not contain any RTL (Register-Transfer Level) code or core descript
 
 Quick start
 -----------
-Install by cloning the repo, cd into fusesoc and run:
 
-    autoreconf -i && ./configure && make
-    sudo make install
+Install from PyPi:
+
+    sudo pip install fusesoc
 
 FuseSoC should now be installed. Next step is to download the standard IP core library (orpsoc-cores). Create a new directory that will be used as a workspace directory for building and simulating cores. Enter the newly created directory and run
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[metadata]
+description-file = readme.md

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,25 @@
+import os
+from setuptools import setup
+
+def read(fname):
+    return open(os.path.join(os.path.dirname(__file__), fname)).read()
+
+setup(
+    name = "fusesoc",
+    packages=['fusesoc', 'fusesoc.build', 'fusesoc.simulator', 'fusesoc.provider'],
+    scripts=["bin/fusesoc"],
+    version = "1.4-dev",
+    author = "Olof Kindgren",
+    author_email = "olof.kindgren@gmail.com",
+    description = ("FuseSoC is a package manager and a set of build tools for HDL (Hardware Description Language) code."),
+    license = "GPLv3",
+    keywords = ["VHDL", "verilog", "hdl", "rtl", "synthesis", "FPGA", "simulation", "Xilinx", "Altera"],
+    url = "https://github.com/olofk/fusesoc",
+    long_description=read('readme.md'),
+    classifiers=[
+        "Development Status :: 3 - Alpha",
+        "Topic :: Utilities",
+        "Topic :: Software Development :: Build Tools",
+        "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
+    ],
+)


### PR DESCRIPTION
For distribution of Python packages, using setuptools is preferred.  This enables the package to be hosted on PyPi, meaning that users can install using `pip`.

Note I haven't created a PyPi entry or tested, however a local pip installation works from the repo:

```
pip install .
```