### PR TITLE
Allow naming of files

### DIFF
--- a/bin/fusesoc
+++ b/bin/fusesoc
@@ -163,7 +163,8 @@ def list_cores(args):
     maxlen = max(map(len,cores.keys()))
     print('Core'.ljust(maxlen) + '   Cache status')
     print("="*80)
-    for name, core in cores.items():
+    for name in sorted(cores.keys()):
+        core = cores[name]
         print(name.ljust(maxlen) + ' : ' + core.cache_status())
 
 def core_info(args):

--- a/fusesoc/core.py
+++ b/fusesoc/core.py
@@ -58,7 +58,7 @@ class Core:
             #FIXME : Make simulators part of the core object
             self.simulator        = config.get_section('simulator')
 
-            for s in section.load_all(config, name=self.name):
+            for s in section.load_all(config, core_file):
                 if type(s) == tuple:
                     _l = getattr(self, s[0].TAG)
                     _l[s[1]] = s[0]

--- a/fusesoc/core.py
+++ b/fusesoc/core.py
@@ -52,7 +52,6 @@ class Core:
         self.export_files = []
         if core_file:
 
-            self.name = basename.split('.core')[0]
             config = FusesocConfigParser(core_file)
 
             #FIXME : Make simulators part of the core object
@@ -67,6 +66,11 @@ class Core:
                     setattr(self, s.TAG, s)
             self.depend     = self.main.depend
             self.simulators = self.main.simulators
+
+            if self.main.name:
+                self.name = self.main.name
+            else:
+                self.name = basename.split('.core')[0]
 
             self._collect_filesets()
 

--- a/fusesoc/coremanager.py
+++ b/fusesoc/coremanager.py
@@ -25,10 +25,11 @@ class CoreManager(object):
             cls._instance = super(CoreManager, cls).__new__(cls, *args, **kwargs)
         return cls._instance
 
-    def load_core(self, name, file):
+    def load_core(self, file):
         if os.path.exists(file):
             try:
-                self._cores[name] = Core(file)
+                core = Core(file)
+                self._cores[core.name] = core
                 logger.debug("Adding core " + file)
             except SyntaxError as e:
                 w = "Failed to parse " + file + ": " + e.msg
@@ -46,7 +47,7 @@ class CoreManager(object):
             for f in files:
                 if f.endswith('.core'):
                     d = os.path.basename(root)
-                    self.load_core(f.rsplit('.',1)[0], os.path.join(root, f))
+                    self.load_core(os.path.join(root, f))
                     del dirs[:]
 
     def add_cores_root(self, path):

--- a/fusesoc/section.py
+++ b/fusesoc/section.py
@@ -413,7 +413,7 @@ class ParameterSection(Section):
         if items:
             self.load_dict(items)
 
-def load_section(config, section_name, name='<unknown>'):
+def load_section(config, section_name, file_name='<unknown>'):
     tmp = section_name.split(' ')
     _type = tmp[0]
     if len(tmp) == 2:
@@ -424,23 +424,23 @@ def load_section(config, section_name, name='<unknown>'):
     if cls is None:
         #Note: The following sections are not in section.py yet
         if not section_name in ['plusargs', 'simulator', 'provider']:
-            pr_warn("Unknown section '{}' in '{}'".format(section_name, name))
+            pr_warn("Unknown section '{}' in '{}'".format(section_name, file_name))
         return None
 
     items = config.get_section(section_name)
     section = cls(items)
     if section.warnings:
         for warning in section.warnings:
-            pr_warn('Warning: %s in %s' % (warning, name))
+            pr_warn('Warning: %s in %s' % (warning, file_name))
     if _name:
         return (section, _name)
     else:
         return section
 
 
-def load_all(config, name='<unknown>'):
+def load_all(config, file_name='<unknown>'):
     for section_name in config.sections():
-        section = load_section(config, section_name, name)
+        section = load_section(config, section_name, file_name)
         if section:
             yield section
 

--- a/fusesoc/section.py
+++ b/fusesoc/section.py
@@ -142,6 +142,7 @@ class MainSection(Section):
     def __init__(self, items=None):
         super(MainSection, self).__init__()
 
+        self._add_member('name'       , str, "Core identifier")
         self._add_member('component'  , PathList, "Core IP-Xact component file")
         self._add_member('description', str, "Core description")
         self._add_member('depend'     , StringList, "Common dependencies")

--- a/fusesoc/system.py
+++ b/fusesoc/system.py
@@ -21,7 +21,7 @@ class System:
         if self.config.has_option('main', 'backend'):
             self.backend_name = self.config.get('main','backend')
             self.backend = section.load_section(self.config, self.backend_name,
-                    name=self.name)
+                                                file_name=system_file)
 
 
     def info(self):


### PR DESCRIPTION
Hi,

these patches are part of the preparation for remote server providing cores. It generally makes sense to allow for names (we may enforce a format later). For now I use names like `oh/common/debouncer` or `wallento/pmod_switchbox` locally for testing a librecores remote API.

Cheers,
Stefan