### PR TITLE
Output filename in core config warnings

### DIFF
--- a/fusesoc/core.py
+++ b/fusesoc/core.py
@@ -58,7 +58,7 @@ class Core:
             #FIXME : Make simulators part of the core object
             self.simulator        = config.get_section('simulator')
 
-            for s in section.load_all(config, name=self.name):
+            for s in section.load_all(config, core_file):
                 if type(s) == tuple:
                     _l = getattr(self, s[0].TAG)
                     _l[s[1]] = s[0]

--- a/fusesoc/coremanager.py
+++ b/fusesoc/coremanager.py
@@ -25,10 +25,11 @@ class CoreManager(object):
             cls._instance = super(CoreManager, cls).__new__(cls, *args, **kwargs)
         return cls._instance
 
-    def load_core(self, name, file):
+    def load_core(self, file):
         if os.path.exists(file):
             try:
-                self._cores[name] = Core(file)
+                core = Core(file)
+                self._cores[core.name] = core
                 logger.debug("Adding core " + file)
             except SyntaxError as e:
                 w = "Failed to parse " + file + ": " + e.msg
@@ -46,7 +47,7 @@ class CoreManager(object):
             for f in files:
                 if f.endswith('.core'):
                     d = os.path.basename(root)
-                    self.load_core(f.rsplit('.',1)[0], os.path.join(root, f))
+                    self.load_core(os.path.join(root, f))
                     del dirs[:]
 
     def add_cores_root(self, path):

--- a/fusesoc/section.py
+++ b/fusesoc/section.py
@@ -414,7 +414,7 @@ class ParameterSection(Section):
         if items:
             self.load_dict(items)
 
-def load_section(config, section_name, name='<unknown>'):
+def load_section(config, section_name, file_name='<unknown>'):
     tmp = section_name.split(' ')
     _type = tmp[0]
     if len(tmp) == 2:
@@ -425,23 +425,23 @@ def load_section(config, section_name, name='<unknown>'):
     if cls is None:
         #Note: The following sections are not in section.py yet
         if not section_name in ['plusargs', 'simulator', 'provider']:
-            pr_warn("Unknown section '{}' in '{}'".format(section_name, name))
+            pr_warn("Unknown section '{}' in '{}'".format(section_name, file_name))
         return None
 
     items = config.get_section(section_name)
     section = cls(items)
     if section.warnings:
         for warning in section.warnings:
-            pr_warn('Warning: %s in %s' % (warning, name))
+            pr_warn('Warning: %s in %s' % (warning, file_name))
     if _name:
         return (section, _name)
     else:
         return section
 
 
-def load_all(config, name='<unknown>'):
+def load_all(config, file_name='<unknown>'):
     for section_name in config.sections():
-        section = load_section(config, section_name, name)
+        section = load_section(config, section_name, file_name)
         if section:
             yield section
 

--- a/fusesoc/system.py
+++ b/fusesoc/system.py
@@ -21,7 +21,7 @@ class System:
         if self.config.has_option('main', 'backend'):
             self.backend_name = self.config.get('main','backend')
             self.backend = section.load_section(self.config, self.backend_name,
-                    name=self.name)
+                                                file_name=system_file)
 
 
     def info(self):


### PR DESCRIPTION
Currently the core name is part of the warning. Use the filename
instead.

This is part of preparing a hierarchical naming scheme for remote
cores.