### PR TITLE
use console_scripts instead of scripts

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,7 +1,0 @@
-engines:
-  pep8:
-    enabled: true
-
-ratings:
-   paths:
-   - "**.py"

--- a/bin/fusesoc
+++ b/bin/fusesoc
@@ -287,7 +287,7 @@ def run(args):
     # Run the function
     args.func(args)
 
-def main():
+if __name__ == "__main__":
     logger.debug("Command line arguments: " + str(sys.argv))
 
     parser = argparse.ArgumentParser()
@@ -353,6 +353,3 @@ def main():
         run(parsed_args)
     else:
         parser.print_help()
-
-if __name__ == "__main__":
-    main()

--- a/fusesoc/main.py
+++ b/fusesoc/main.py
@@ -287,7 +287,7 @@ def run(args):
     # Run the function
     args.func(args)
 
-if __name__ == "__main__":
+def main():
     logger.debug("Command line arguments: " + str(sys.argv))
 
     parser = argparse.ArgumentParser()
@@ -353,3 +353,6 @@ if __name__ == "__main__":
         run(parsed_args)
     else:
         parser.print_help()
+
+if __name__ == "__main__":
+    main()

--- a/readme.md
+++ b/readme.md
@@ -1,8 +1,3 @@
-[![Travis Build Status](https://travis-ci.org/nturley/fusesoc.svg?branch=ci)](https://travis-ci.org/nturley/fusesoc)
-[![Appveyor Build Status](https://ci.appveyor.com/api/projects/status/github/nturley/fusesoc?branch=ci)](https://ci.appveyor.com/project/nturley/fusesoc)
-[![PyPI version](https://badge.fury.io/py/fusesoc.svg)](https://badge.fury.io/py/fusesoc)
-[![Code Health](https://landscape.io/github/nturley/fusesoc/ci/landscape.svg?style=flat)](https://landscape.io/github/nturley/fusesoc/ci)
-[![Code Climate](https://codeclimate.com/github/nturley/fusesoc/badges/gpa.svg)](https://codeclimate.com/github/nturley/fusesoc)
 FuseSoC
 =======
 

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,6 @@ setup(
               'fusesoc.ipyxact',
               'fusesoc.simulator',
               'fusesoc.provider'],
-    scripts=["bin/fusesoc"],
     version = "1.4",
     author = "Olof Kindgren",
     author_email = "olof.kindgren@gmail.com",
@@ -25,5 +24,13 @@ setup(
         "Topic :: Utilities",
         "Topic :: Software Development :: Build Tools",
         "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
+    ],
+    entry_points={
+        'console_scripts': [
+            'fusesoc = fusesoc.main:main'
+        ]
+    },
+    install_requires=[
+          'pyyaml',
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,7 @@ setup(
               'fusesoc.ipyxact',
               'fusesoc.simulator',
               'fusesoc.provider'],
+    scripts=["bin/fusesoc"],
     version = "1.4",
     author = "Olof Kindgren",
     author_email = "olof.kindgren@gmail.com",
@@ -24,13 +25,5 @@ setup(
         "Topic :: Utilities",
         "Topic :: Software Development :: Build Tools",
         "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
-    ],
-    entry_points={
-        'console_scripts': [
-            'fusesoc = fusesoc.main:main'
-        ]
-    },
-    install_requires=[
-          'pyyaml',
     ],
 )


### PR DESCRIPTION
this change addresses #104. This page explains more about it.
https://setuptools.readthedocs.io/en/latest/setuptools.html#automatic-script-creation

Instead of copying business logic to Scripts, setuptools automatically generates a python file that calls into an entry point and places it in scripts. On windows machines, it generates an exe shim. It should be a little more cross-platform friendly, and a little more maintainable.

I also added pyyaml as a dependency in setup.py so pip automatically installs it.

To make it work, I renamed bin/fusesoc to fusesoc/main.py. This might break your development workflow. I recommend using a virtual environment and calling
`pip install -e .`
That will add your development version of fusesoc to your path.