### PR TITLE
Fix failure when no parameters set

### DIFF
--- a/fusesoc/edatool.py
+++ b/fusesoc/edatool.py
@@ -37,6 +37,11 @@ class EdaTool(object):
         self.env = os.environ.copy()
         self.env['BUILD_ROOT'] = os.path.abspath(self.build_root)
 
+        self.plusarg    = {}
+        self.vlogparam  = {}
+        self.generic    = {}
+        self.cmdlinearg = {}
+
     def configure(self, args):
         if os.path.exists(self.work_root):
             for f in os.listdir(self.work_root):
@@ -104,11 +109,6 @@ class EdaTool(object):
                                                                                                    core.name))
                     all_params[param_name.replace('-','_')] = param.paramtype
         p = parser.parse_args(args)
-
-        self.plusarg    = {}
-        self.vlogparam  = {}
-        self.generic    = {}
-        self.cmdlinearg = {}
 
         for key,value in vars(p).items():
             paramtype = all_params[key]

--- a/fusesoc/simulator/simulator.py
+++ b/fusesoc/simulator/simulator.py
@@ -62,8 +62,8 @@ class Simulator(EdaTool):
 
         return (src_files, incdirs)
 
-    def configure(self, args):
-        if not hasattr(self, 'plusarg'):
+    def configure(self, args, skip_params = False):
+        if not skip_params:
             self.parse_args(args, 'sim', ['plusarg', 'vlogparam'])
         self.work_root = self.sim_root
         super(Simulator, self).configure(args)

--- a/fusesoc/simulator/verilator.py
+++ b/fusesoc/simulator/verilator.py
@@ -66,9 +66,8 @@ class Verilator(Simulator):
                                 os.path.join(dst_dir, f))
 
     def configure(self, args):
-        if not self.fusesoc_cli_parser:
-            self.plusarg = []
-        super(Verilator, self).configure(args)
+        skip = not self.fusesoc_cli_parser
+        super(Verilator, self).configure(args, skip_params = skip)
         self.export()
         self._write_config_files()
         #self.object_files = [os.path.splitext(os.path.basename(s))[0]+'.o' for s in self.src_files]


### PR DESCRIPTION
When running FuseSoC without parameters the backends (e.g., verilator)
failed because the members like vlogparam are missing. Hence, create
them at init.