### PR TITLE
Run make with multiple parallel jobs

### DIFF
--- a/fusesoc/simulator/verilator.py
+++ b/fusesoc/simulator/verilator.py
@@ -1,4 +1,5 @@
 import logging
+import multiprocessing
 import os
 import shutil
 
@@ -155,8 +156,11 @@ class Verilator(Simulator):
             if core.verilator:
                  self._build(core, self.sim_root, self.src_root)
 
+        # Do parallel builds with <number of cpus> * 2 jobs.
+        make_job_count = multiprocessing.cpu_count() * 2
+
         pr_info("Building verilator executable:")
-        args = ['-f', 'V' + self.top_module + '.mk', 'V' + self.top_module]
+        args = ['-f', 'V' + self.top_module + '.mk', '-j', str(make_job_count), 'V' + self.top_module]
         l = utils.Launcher('make', args,
                        cwd=os.path.join(self.sim_root, 'obj_dir'),
                        stdout = open(os.path.join(self.sim_root,


### PR DESCRIPTION
Verilator runs gcc, which can be parallelized easily and produces great
speedups in compile time.
This patch uses NUMBER_OF_CPUS * 2 parallel jobs (if possible), a
commonly used default value.