### PR TITLE
Verilator: Command line args

### DIFF
--- a/fusesoc/coremanager.py
+++ b/fusesoc/coremanager.py
@@ -97,7 +97,7 @@ class CoreDB(object):
         installed_repository = Repository()
         pool = Pool([repo])
         pool.add_repository(installed_repository)
-        solver = DependencySolver(pool, repo, installed_repository)
+        solver = DependencySolver(pool, [repo], installed_repository)
 
         try:
             transaction = solver.solve(request)

--- a/fusesoc/simulator/simulator.py
+++ b/fusesoc/simulator/simulator.py
@@ -41,7 +41,7 @@ class Simulator(EdaTool):
 
     def configure(self, args, skip_params = False):
         if not skip_params:
-            self.parse_args(args, 'sim', ['plusarg', 'vlogdefine', 'vlogparam'])
+            self.parse_args(args, 'sim', ['plusarg', 'vlogdefine', 'vlogparam', 'cmdlinearg'])
         super(Simulator, self).configure(args)
 
     def build(self):
@@ -54,7 +54,7 @@ class Simulator(EdaTool):
         return
 
     def run(self, args):
-        self.parse_args(args, 'sim', ['plusarg', 'vlogdefine', 'vlogparam'])
+        self.parse_args(args, 'sim', ['plusarg', 'vlogdefine', 'vlogparam', 'cmdlinearg'])
         for core in self.cores:
             if core.scripts:
                 run_scripts(core.scripts.pre_run_scripts,

--- a/fusesoc/simulator/verilator.py
+++ b/fusesoc/simulator/verilator.py
@@ -129,6 +129,8 @@ class Verilator(Simulator):
             _args = []
             for key, value in self.plusarg.items():
                 _args += ['+{}={}'.format(key, value)]
+            for key, value in self.cmdlinearg.items():
+                _args += ['--{}={}'.format(key, value)]
         else:
             _args = args
         pr_info("Running simulation")

--- a/fusesoc/simulator/verilator.py
+++ b/fusesoc/simulator/verilator.py
@@ -85,6 +85,8 @@ class Verilator(Simulator):
             f.write('--exe\n')
             f.write('\n'.join(opt_c_files))
             f.write('\n')
+            f.write(''.join(['-G{}={}\n'.format(key, value) for key, value in self.vlogparam.items()]))
+            f.write(''.join(['-D{}={}\n'.format(key, value) for key, value in self.vlogdefine.items()]))
 
         with open(os.path.join(self.work_root, 'Makefile'), 'w') as makefile:
             makefile.write(MAKEFILE_TEMPLATE)
@@ -121,8 +123,7 @@ class Verilator(Simulator):
 
     def run(self, args):
         fusesoc_cli_parser = (self.system.verilator.cli_parser == 'fusesoc')
-        if fusesoc_cli_parser:
-            self.plusarg = []
+
         super(Verilator, self).run(args)
 
         if fusesoc_cli_parser:

--- a/setup.py
+++ b/setup.py
@@ -30,8 +30,7 @@ setup(
         ]
     },
     install_requires=[
-          'attrs==16.0.0', #Workaround for broken pip dep handler
           'ipyxact>=0.2.3',
-          'simplesat==0.7.0',
+          'simplesat',
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,6 @@ setup(
     },
     install_requires=[
           'ipyxact>=0.2.3',
-          'simplesat',
+          'simplesat>=0.8.0',
     ],
 )

--- a/tests/cores/misc/paramtest.core
+++ b/tests/cores/misc/paramtest.core
@@ -54,3 +54,21 @@ datatype  = str
 description = string verilog plusarg
 paramtype = plusarg
 scope = public
+
+[parameter cmdlinearg_bool]
+datatype  = bool
+description = boolean verilog cmdlinearg
+paramtype = cmdlinearg
+scope = public
+
+[parameter cmdlinearg_int]
+datatype  = int
+description = integer verilog cmdlinearg
+paramtype = cmdlinearg
+scope = public
+
+[parameter cmdlinearg_str]
+datatype  = str
+description = string verilog cmdlinearg
+paramtype = cmdlinearg
+scope = public

--- a/tests/cores/mor1kx-generic/mor1kx-generic.core
+++ b/tests/cores/mor1kx-generic/mor1kx-generic.core
@@ -43,6 +43,7 @@ depend = verilator_tb_utils
 verilator_options = -Wno-fatal --trace
 tb_toplevel   = bench/verilator/tb.cpp
 top_module    = orpsoc_top
+cli_parser    = fusesoc
 
 [parameter clear_ram]
 datatype    = bool

--- a/tests/test_verilator.py
+++ b/tests/test_verilator.py
@@ -22,6 +22,7 @@ def test_verilator_configure():
     tests_dir = os.path.dirname(__file__)
     params = '--vlogparam_bool --vlogparam_int=42 --vlogparam_str=hello'
     params += ' --vlogdefine_bool --vlogdefine_int=42 --vlogdefine_str=hello'
+    params += ' --cmdlinearg_bool --cmdlinearg_int=42 --cmdlinearg_str=hello'
 
     Config().build_root = os.path.join(tests_dir, 'build')
     Config().cache_root = os.path.join(tests_dir, 'cache')
@@ -47,6 +48,7 @@ def test_verilator_run():
     tests_dir = os.path.dirname(__file__)
     params = '--vlogparam_bool --vlogparam_int=42 --vlogparam_str=hello'
     params += ' --vlogdefine_bool --vlogdefine_int=42 --vlogdefine_str=hello'
+    params += ' --cmdlinearg_bool --cmdlinearg_int=42 --cmdlinearg_str=hello'
 
     Config().build_root = os.path.join(tests_dir, 'build')
     Config().cache_root = os.path.join(tests_dir, 'cache')

--- a/tests/test_verilator/mor1kx-generic_0.vc
+++ b/tests/test_verilator/mor1kx-generic_0.vc
@@ -80,3 +80,9 @@
 ../../../cores/verilator_tb_utils/verilator_tb_utils.cpp
 ../../../cores/verilator_tb_utils/jtagServer.cpp
 ../../../cores/mor1kx-generic/bench/verilator/tb.cpp
+-Gvlogparam_bool=true
+-Gvlogparam_int=42
+-Gvlogparam_str="hello"
+-Dvlogdefine_bool=true
+-Dvlogdefine_int=42
+-Dvlogdefine_str=hello

--- a/tests/test_verilator/run.cmd
+++ b/tests/test_verilator/run.cmd
@@ -1,1 +1,1 @@
---vlogparam_bool --vlogparam_int=42 --vlogparam_str=hello --vlogdefine_bool --vlogdefine_int=42 --vlogdefine_str=hello
+--vlogparam_bool --vlogparam_int=42 --vlogparam_str=hello --vlogdefine_bool --vlogdefine_int=42 --vlogdefine_str=hello --cmdlinearg_bool --cmdlinearg_int=42 --cmdlinearg_str=hello

--- a/tests/test_verilator/run.cmd
+++ b/tests/test_verilator/run.cmd
@@ -1,1 +1,1 @@
---vlogparam_bool --vlogparam_int=42 --vlogparam_str=hello --vlogdefine_bool --vlogdefine_int=42 --vlogdefine_str=hello --cmdlinearg_bool --cmdlinearg_int=42 --cmdlinearg_str=hello
+--cmdlinearg_bool=true --cmdlinearg_int=42 --cmdlinearg_str=hello


### PR DESCRIPTION
Add command line arg forwarding for Verilator. A core (the testbench
usually) can set a parameter like this:

    [parameter vcd]
    datatype = bool
    paramtype = cmdlinearg
    scope = public

It is forwarded as `--vcd=1` to the simulation then.