### PR TITLE
vivado: Make our run the default run

### DIFF
--- a/fusesoc/build/vivado.py
+++ b/fusesoc/build/vivado.py
@@ -169,14 +169,16 @@ set_property include_dirs [list {incdirs}] [get_filesets sources_1]
 
 {extras}
 
-regexp -- {{Vivado v([0-9]{{4}})\.[0-9]}} [version] -> year
+# By default create_project creates the synth_1 and impl_1 runs.
+# To explicitly create customized runs, uncomment the code below.
+#regexp -- {{Vivado v([0-9]{{4}})\.[0-9]}} [version] -> year
+#create_run synth_1 -quiet -flow "Vivado Synthesis $year" -strategy "Vivado Synthesis Defaults"
+#create_run impl_1 -quiet -flow "Vivado Implementation $year" -strategy "Vivado Implementation Defaults" -parent_run synth_1
+#current_run [get_runs synth_1]
 
-create_run -name synthesis -flow "Vivado Synthesis $year" -strategy "Vivado Synthesis Defaults"
-create_run implementation -flow "Vivado Implementation $year" -strategy "Vivado Implementation Defaults" -parent_run synthesis
-
-launch_runs implementation
-wait_on_run implementation
-open_run implementation
+launch_runs impl_1
+wait_on_run impl_1
+open_run impl_1
 write_bitstream {bitstream}
 """
 

--- a/tests/test_vivado/mor1kx-arty_0.tcl
+++ b/tests/test_vivado/mor1kx-arty_0.tcl
@@ -67,12 +67,14 @@ read_xdc ../../../cores/misc/xdc_file
 set_param project.enableVHDL2008 1
 set_property top mor1kx_arty_top [current_fileset]
 
-regexp -- {Vivado v([0-9]{4})\.[0-9]} [version] -> year
+# By default create_project creates the synth_1 and impl_1 runs.
+# To explicitly create customized runs, uncomment the code below.
+#regexp -- {Vivado v([0-9]{4})\.[0-9]} [version] -> year
+#create_run synth_1 -quiet -flow "Vivado Synthesis $year" -strategy "Vivado Synthesis Defaults"
+#create_run impl_1 -quiet -flow "Vivado Implementation $year" -strategy "Vivado Implementation Defaults" -parent_run synth_1
+#current_run [get_runs synth_1]
 
-create_run -name synthesis -flow "Vivado Synthesis $year" -strategy "Vivado Synthesis Defaults"
-create_run implementation -flow "Vivado Implementation $year" -strategy "Vivado Implementation Defaults" -parent_run synthesis
-
-launch_runs implementation
-wait_on_run implementation
-open_run implementation
+launch_runs impl_1
+wait_on_run impl_1
+open_run impl_1
 write_bitstream mor1kx-arty_0.bit


### PR DESCRIPTION
When opening the fusesoc-generated project in the Vivado GUI it shows a
new and empty synth_1 and impl_1 run as default instead of the one
already finished.

This set uses the runs created by default in Vivado's create_project,
avoiding the manual creation of the runs. (I've left the code to do so
in the TCL file as a starting point for manual adjustment should
multiple runs be required.)

Before screenshot:
![image](https://cloud.githubusercontent.com/assets/1467123/26208897/910560c6-3beb-11e7-83b6-fd3d2cfae22b.png)

