### PR TITLE
Fix passing of generics/parameters to Vivado

### DIFF
--- a/fusesoc/build/vivado.py
+++ b/fusesoc/build/vivado.py
@@ -87,11 +87,14 @@ class Vivado(Backend):
             extras += "set_param project.enableVHDL2008 1\n"
 
         parameters = ""
-        for key, value in self.vlogparam.items():
-            parameters += "set_property generic {{{key}={value}}} [get_filesets sources_1]\n".format(key=key, value=self._param_value_str(value))
+
+        if len(self.vlogparam.items()) > 0:
+            generics = " ".join(k+"="+self._param_value_str(v) for k,v in self.vlogparam.items())
+            parameters += "set_property generic {"+generics+"} [get_filesets sources_1]\n"
 
         if len(self.vlogdefine.items()) > 0:
-            parameters += "set_property verilog_define \"{}\" [get_filesets sources_1]\n".format(" ".join(k+"="+self._param_value_str(v) for k,v in self.vlogdefine.items()))
+            defines = " ".join(k+"="+self._param_value_str(v) for k,v in self.vlogdefine.items())
+            parameters += "set_property verilog_define \""+defines+"\" [get_filesets sources_1]\n"
 
         if self.toplevel:
             extras += "set_property top "+self.toplevel+" [current_fileset]"

--- a/tests/test_vivado/mor1kx-arty_0.tcl
+++ b/tests/test_vivado/mor1kx-arty_0.tcl
@@ -54,9 +54,7 @@ read_vhdl ../../../cores/misc/vhdl_file.vhd
 read_vhdl -library libx ../../../cores/misc/vhdl_lib_file.vhd
 read_vhdl -vhdl2008 ../../../cores/misc/vhdl2008_file.vhd
 
-set_property generic {vlogparam_bool=1} [get_filesets sources_1]
-set_property generic {vlogparam_int=42} [get_filesets sources_1]
-set_property generic {vlogparam_str=hello} [get_filesets sources_1]
+set_property generic {vlogparam_bool=1 vlogparam_int=42 vlogparam_str=hello} [get_filesets sources_1]
 set_property verilog_define "vlogdefine_bool=1 vlogdefine_int=42 vlogdefine_str=hello" [get_filesets sources_1]
 
 


### PR DESCRIPTION
Using set_property multiple times in Vivado overrides the previously set
value. In the case of generics/parameters, this caused only the last
parameter to be set during synthesis, all other parameters are ignored.