### PR TITLE
Implement add-paths command

### DIFF
--- a/fusesoc/config.py
+++ b/fusesoc/config.py
@@ -32,13 +32,13 @@ class Config(object):
         xdg_config_home = os.environ.get('XDG_CONFIG_HOME') or \
                           os.path.join(os.path.expanduser('~'), '.config')
         config = configparser.SafeConfigParser()
-        config_files = ['/etc/fusesoc/fusesoc.conf',
+        candidate_files = ['/etc/fusesoc/fusesoc.conf',
                         os.path.join(xdg_config_home, 'fusesoc','fusesoc.conf'),
                         'fusesoc.conf']
 
-        logger.debug('Looking for config files from ' + ':'.join(config_files))
-        files_read = config.read(config_files)
-        logger.debug('Found config files in ' + ':'.join(files_read))
+        logger.debug('Looking for config files from ' + ':'.join(candidate_files))
+        self.config_files = config.read(candidate_files)
+        logger.debug('Found config files in ' + ':'.join(self.config_files))
 
         for item in ['build_root', 'cache_root', 'systems_root']:
             try:

--- a/fusesoc/main.py
+++ b/fusesoc/main.py
@@ -140,14 +140,23 @@ def list_paths(args):
     print("\n".join(cores_root))
     
 def add_paths(args):
-    config_file = Config().config_files[-1]
-    logger.debug("Modifying " + config_file)
     parser = configparser.ConfigParser()
-    parser.read(config_file)
-    try:
-        current_roots = parser.get("main", "cores_root")
-    except (configparser.NoSectionError, configparser.NoOptionError):
-        logger.warning("Config file {} does not contain a cores_root option".format(config_file))
+    if Config().config_files:
+        config_file = Config().config_files[-1]
+        logger.debug("Modifying " + config_file)
+        parser.read(config_file)
+        try:
+            current_roots = parser.get("main", "cores_root")
+        except (configparser.NoSectionError, configparser.NoOptionError):
+            logger.warning("Config file {} does not contain a cores_root option".format(config_file))
+            current_roots = ""
+    else:
+        xdg_config_home = os.environ.get('XDG_CONFIG_HOME') or \
+                          os.path.join(os.path.expanduser('~'), '.config')
+        config_file = os.path.join(xdg_config_home, 'fusesoc','fusesoc.conf')
+        if not os.path.exists(os.path.dirname(config_file)):
+            os.makedirs(os.path.dirname(config_file))
+        logger.warning("No config file found - creating one at " + config_file)
         current_roots = ""
     if not parser.has_section("main"):
         parser.add_section("main")


### PR DESCRIPTION
I found myself wanting an easy way to add a core root path without manually editing the configuration file(s), so I implemented an add-paths command in the same vein as the list-paths command.

I hope this is useful. It's maybe not the prettiest patch - if you want me to refactor it in some way please let me know.