### PR TITLE
Add Cygpath handling for misbehaving subprocesses

### DIFF
--- a/fusesoc/config.py
+++ b/fusesoc/config.py
@@ -15,6 +15,7 @@ class Config(object):
     _init_done = False
 
     archbits = 0
+    cygpath=False
     def __new__(cls, *args, **kwargs):
         if not cls._instance:
             cls._instance = super(Config, cls).__new__(cls, *args, **kwargs)

--- a/fusesoc/main.py
+++ b/fusesoc/main.py
@@ -297,6 +297,12 @@ def run(args):
     else:
         config.archbits = 64 if platform.architecture()[0] == '64bit' else 32
         logger.debug("Autodetected " + str(config.archbits) + "-bit mode")
+    if sys.platform == "win32":
+        config.cygpath = vars(args)['cygpath']
+        if config.cygpath:
+            logger.debug("Using cygpath translation")
+        else:
+            logger.debug("Using native Windows paths")
     # Run the function
     args.func(args)
 
@@ -314,6 +320,7 @@ def main():
     parser.add_argument('--64', help='Force 64 bit mode for invoked tools', action='store_true')
     parser.add_argument('--monochrome', help='Don\'t use color for messages', action='store_true')
     parser.add_argument('--verbose', help='More info messages', action='store_true')
+    parser.add_argument('--cygpath', help='Use POSIX paths on Windows (no effect on POSIX systems)', action='store_true')
 
     # build subparser
     parser_build = subparsers.add_parser('build', help='Build an FPGA load module')

--- a/fusesoc/provider/opencores.py
+++ b/fusesoc/provider/opencores.py
@@ -1,7 +1,9 @@
 import logging
+import sys
 
 from fusesoc.provider.provider import Provider
-from fusesoc.utils import Launcher
+from fusesoc.utils import Launcher, cygpath
+from fusesoc.config import Config
 
 logger = logging.getLogger(__name__)
 
@@ -16,6 +18,9 @@ class Opencores(Provider):
                                      self.config.get('repo_root'))
         revision_number  = self.config.get('revision')
         logger.info("Downloading " + repo_name + " from OpenCores")
+
+        if sys.platform == "win32" and Config().cygpath:
+            local_dir = cygpath(local_dir)
 
         Launcher('svn', ['co', '-q', '--no-auth-cache',
                          '-r', revision_number,

--- a/fusesoc/utils.py
+++ b/fusesoc/utils.py
@@ -47,6 +47,10 @@ class Launcher:
     def __str__(self):
         return ' '.join([self.cmd] + self.args)
 
+def cygpath(win_path):
+    path = subprocess.check_output(["cygpath", "-u", win_path])
+    return path.decode('ascii').strip()
+
 #Copied from http://twistedmatrix.com/trac/browser/tags/releases/twisted-8.2.0/twisted/python/procutils.py
 
 #Permission is hereby granted, free of charge, to any person obtaining


### PR DESCRIPTION
The Python interpreter has a few versions on Windows:
* The `mvsc` one provided by the official installer and conda
* The `gnu` ABI version provided by `msys2`
* `cygwin`, a POSIX wrapper
* A `midipix` version in the future, which is a superior POSIX wrapper.

Depending on what version/package you use, you can end up in an environment (and _not_ just due to the `PATH` variable) where Python invokes a tool that doesn't understand Windows paths. This patch adds an option to force using POSIX style PATHs if necessary using the `--cygpath` flag. The `--cygpath` flag is optional, and `Provider`s must manually provide support for the flag.

There are many cases where the `--cygpath` flag isn't required, and might not even be useful. For instance, a user who installed the `msvc` build of Python might have only binaries on the path which don't support POSIX-style paths at all. This patch is meant to be a compromise to support users who don't have (or don't want) to install a POSIX environment on Windows, and those (like myself) who basically only use `mingw`/`gnu` ABI binaries.