### PR TITLE
Support user files for Vivado, XSim, Verilator, ISim, IceStorm, Icarus, GHDL

### DIFF
--- a/fusesoc/edatools/ghdl.py
+++ b/fusesoc/edatools/ghdl.py
@@ -50,6 +50,8 @@ class Ghdl(Simulator):
                 Launcher(cmd, args,
                          cwd      = self.work_root,
                          errormsg = "Failed to analyze {}".format(f.name)).run()
+            elif f.file_type in ["user"]:
+                pass
             else:
                 _s = "{} has unknown file type '{}'"
                 logger.warning(_s.format(f.name, f.file_type))

--- a/fusesoc/edatools/icarus.py
+++ b/fusesoc/edatools/icarus.py
@@ -54,6 +54,8 @@ clean_{name}:
 			              "systemVerilogSource-3.1",
 			              "systemVerilogSource-3.1a"]:
                 f.write(src_file.name+'\n')
+            elif src_file.file_type == 'user':
+                pass
             else:
                 _s = "{} has unknown file type '{}'"
                 logger.warning(_s.format(src_file.name, src_file.file_type))

--- a/fusesoc/edatools/icestorm.py
+++ b/fusesoc/edatools/icestorm.py
@@ -51,6 +51,8 @@ ARACHNE_PNR_OPTIONS := {arachne_pnr_options}
                     yosys_file.write("read_verilog {}\n".format(f.name))
                 elif f.file_type == 'PCF':
                     pcf_files.append(f.name)
+                elif f.file_type == 'user':
+                    pass
             for key, value in self.vlogparam.items():
                 _s = "chparam -set {} {} $abstract\{}\n"
                 yosys_file.write(_s.format(key,

--- a/fusesoc/edatools/isim.py
+++ b/fusesoc/edatools/isim.py
@@ -31,6 +31,8 @@ class Isim(Simulator):
                                         "systemVerilogSource-3.1a",
                                         "verilogSource-2005"]:
                 f1.write('sv work ' + src_file.name + '\n')
+            elif src_file.file_type in ["user"]:
+                pass
             else:
                 _s = "{} has unknown file type '{}'"
                 logger.warning(_s.format(src_file.name,

--- a/fusesoc/edatools/verilator.py
+++ b/fusesoc/edatools/verilator.py
@@ -71,6 +71,8 @@ class Verilator(Simulator):
                     f.write(src_file.name + '\n')
                 elif src_file.file_type in ['cppSource', 'systemCSource', 'cSource']:
                     opt_c_files.append(src_file.name)
+                elif src_file.file_type in ['user']:
+                    pass
             f.write('--top-module {}\n'.format(self.toplevel))
             f.write('--exe\n')
             f.write('\n'.join(opt_c_files))

--- a/fusesoc/edatools/vivado.py
+++ b/fusesoc/edatools/vivado.py
@@ -74,6 +74,8 @@ class Vivado(Backend):
                 vhdl.append(params+s.name)
             elif s.file_type.startswith('tclSource'):
                 tcl.append(s.name)
+            elif s.file_type == 'user':
+                pass
 
         tcl_file = open(os.path.join(self.work_root, self.name+".tcl"), 'w')
 

--- a/fusesoc/edatools/xsim.py
+++ b/fusesoc/edatools/xsim.py
@@ -35,6 +35,8 @@ class Xsim(Simulator):
                                         "systemVerilogSource-3.1a",
                                         "verilogSource-2005"]:
                 f1.write('sv work ' + src_file.name + '\n')
+            elif src_file.file_type in ["user"]:
+                pass
             else:
                 _s = "{} has unknown file type '{}'"
                 logger.warning(_s.format(src_file.name, src_file.file_type))


### PR DESCRIPTION
Hi! This should add support for `file_type=user` to backends Vivado, XSim, Verilator, ISim, IceStorm, Icarus, GHDL, solving issue #168.