### PR TITLE
Add "quit" statement to isim.tcl to end simulation

### DIFF
--- a/fusesoc/edatools/isim.py
+++ b/fusesoc/edatools/isim.py
@@ -20,8 +20,8 @@ class Isim(Simulator):
         (src_files, self.incdirs) = self._get_fileset_files()
         for src_file in src_files:
             if src_file.file_type in ["verilogSource",
-		                      "verilogSource-95",
-		                      "verilogSource-2001"]:
+                              "verilogSource-95",
+                              "verilogSource-2001"]:
                 f1.write('verilog work ' + src_file.name + '\n')
             elif src_file.file_type.startswith("vhdlSource"):
                 f1.write('vhdl work ' + src_file.logical_name + " " + src_file.name + '\n')
@@ -43,6 +43,7 @@ class Isim(Simulator):
         f2 = open(os.path.join(self.work_root,tcl_file),'w')
         f2.write('wave log -r /\n')
         f2.write('run all\n')
+        f2.write('quit\n')
         f2.close()
 
     def build_main(self):


### PR DESCRIPTION
Adding a quit statement to the isim.tcl will leave the simulator when the test bench runs out of stimuli (e.g. with stopping the clock as soon a desired simulation result is reached).
(Sorry for the whitespace change in line 23..24)