### PR TITLE
Add Support for Xilinx bmm Files for ISE

### DIFF
--- a/fusesoc/core.py
+++ b/fusesoc/core.py
@@ -386,7 +386,9 @@ class Core:
             elif _bname == 'ise':
                 _files += _append_files(_b.tcl_files, 'tclSource')
                 _files += _append_files(_b.ucf_files, 'UCF')
+                _files += _append_files(_b.bmm_files, 'BMM')
                 del(_b.ucf_files)
+                del(_b.bmm_files)
             elif _bname == 'quartus':
                 _files += _append_files(_b.qsys_files, 'QSYS')
                 _files += _append_files(_b.sdc_files, 'SDC')

--- a/fusesoc/edatools/ise.py
+++ b/fusesoc/edatools/ise.py
@@ -68,6 +68,8 @@ quit
                 tcl_file.write('xfile add {}\n'.format(f.name))
             elif f.file_type == 'UCF':
                 tcl_file.write('xfile add {}\n'.format(f.name))
+            elif f.file_type == 'BMM':
+                tcl_file.write('xfile add {}\n'.format(f.name))
             elif f.file_type.startswith('vhdlSource'):
                 if f.logical_name:
                     if not f.logical_name in _libraries:

--- a/fusesoc/edatools/isim.py
+++ b/fusesoc/edatools/isim.py
@@ -20,8 +20,8 @@ class Isim(Simulator):
         (src_files, self.incdirs) = self._get_fileset_files()
         for src_file in src_files:
             if src_file.file_type in ["verilogSource",
-		                      "verilogSource-95",
-		                      "verilogSource-2001"]:
+                              "verilogSource-95",
+                              "verilogSource-2001"]:
                 f1.write('verilog work ' + src_file.name + '\n')
             elif src_file.file_type.startswith("vhdlSource"):
                 f1.write('vhdl work ' + src_file.logical_name + " " + src_file.name + '\n')
@@ -43,6 +43,7 @@ class Isim(Simulator):
         f2 = open(os.path.join(self.work_root,tcl_file),'w')
         f2.write('wave log -r /\n')
         f2.write('run all\n')
+        f2.write('quit\n')
         f2.close()
 
     def build_main(self):

--- a/fusesoc/section.py
+++ b/fusesoc/section.py
@@ -30,6 +30,7 @@ Example: data/mem_init_file.bin[copyto=out/boot.bin]
         'QIP',
         'SDC',
         'UCF',
+        'BMM',
         'tclSource',
         'user',
         'verilogSource',
@@ -522,6 +523,7 @@ class IseSection(ToolSection):
         super(IseSection, self).__init__()
 
         self._add_member('ucf_files' , FileList, "UCF constraint files")
+        self._add_member('bmm_files' , FileList, "bmm constraint files")
         self._add_member('tcl_files' , FileList, "Extra TCL scripts")
         self._add_member('family'    , str, 'FPGA device family')
         self._add_member('device'    , str, 'FPGA device identifier')


### PR DESCRIPTION

bmm (Block Memory Map) type files are used by Xilinx tools to update the Block RAM contents in a generated bitstream without re-synthesis. For details how this work, check the Xilinx documentation, specifically for the data2mem tool.

See the commit comment for further details. 
Maybe the patch is not "production" quality, see also my remarks on limitations/issues in the commit comment. 

Thomas


