### PR TITLE
Reverse the -r run command arguments.

### DIFF
--- a/fusesoc/edatools/ghdl.py
+++ b/fusesoc/edatools/ghdl.py
@@ -64,9 +64,9 @@ class Ghdl(Simulator):
 
         cmd = 'ghdl'
         args = ['-r']
-        if 'run_options' in self.tool_options:
-            args += self.tool_options['run_options']
         args += [self.toplevel]
+        if 'run_options' in self.tool_options:
+            args += self.tool_options['run_options'] 
         Launcher(cmd, args,
                  cwd      = self.work_root,
                  errormsg = "Simulation failed").run()


### PR DESCRIPTION
The run_options have to come after the module name for this to work. 
Options like the following have to come after the module name to work:
run_options = --stop-time=100ms --wave=simulation.ghw --fst=simulation.fst --vcdgz=simulation.vcdgz --vcd=simulation.vcd

https://ghdl.readthedocs.io/en/latest/Invoking_GHDL.html