### PR TITLE
Remove global singletons from codebase

### DIFF
--- a/fusesoc/config.py
+++ b/fusesoc/config.py
@@ -12,7 +12,6 @@ logger = logging.getLogger(__name__)
 
 class Config(object):
     archbits = 0
-    cygpath=False
 
     def __init__(self):
         #TODO: Add option to load custom config file

--- a/fusesoc/config.py
+++ b/fusesoc/config.py
@@ -11,20 +11,11 @@ import os
 logger = logging.getLogger(__name__)
 
 class Config(object):
-    _instance = None
-    _init_done = False
-
     archbits = 0
     cygpath=False
-    def __new__(cls, *args, **kwargs):
-        if not cls._instance:
-            cls._instance = super(Config, cls).__new__(cls, *args, **kwargs)
-        return cls._instance
 
     def __init__(self):
         #TODO: Add option to load custom config file
-        if self._init_done:
-            return
         self.build_root = None
         self.cache_root = None
         self.cores_root = []
@@ -74,4 +65,3 @@ class Config(object):
         logger.debug('cache_root='+self.cache_root)
         logger.debug('cores_root='+':'.join(self.cores_root))
         logger.debug('systems_root='+self.systems_root if self.systems_root else "Not defined")
-        self._init_done = True

--- a/fusesoc/core.py
+++ b/fusesoc/core.py
@@ -41,7 +41,7 @@ class FileSet(object):
         return s
 
 class Core:
-    def __init__(self, core_file):
+    def __init__(self, core_file, cache_root, build_root):
         basename = os.path.basename(core_file)
         self.depend = []
         self.simulators = []
@@ -59,6 +59,7 @@ class Core:
 
         self.core_root = os.path.dirname(core_file)
         self.files_root = self.core_root
+        self.build_root = build_root
 
         self.export_files = []
 
@@ -102,7 +103,7 @@ class Core:
 
         self._collect_filesets()
 
-        cache_root = os.path.join(Config().cache_root, self.sanitized_name)
+        cache_root = os.path.join(cache_root, self.sanitized_name)
         if config.has_section('plusargs'):
             self._warning("plusargs section is deprecated and will not be parsed by FuseSoC. Please migrate to parameters")
             self.plusargs = Plusargs(dict(config.items('plusargs')))
@@ -173,7 +174,7 @@ class Core:
     def get_scripts(self, flags):
         scripts = {}
         if self.scripts:
-            env = {'BUILD_ROOT' : Config().build_root}
+            env = {'BUILD_ROOT' : self.build_root}
             flow = self._get_flow(flags)
             if flow is 'sim':
                 for s in ['pre_build_scripts', 'pre_run_scripts', 'post_run_scripts']:

--- a/fusesoc/coremanager.py
+++ b/fusesoc/coremanager.py
@@ -127,12 +127,9 @@ class CoreManager(object):
     db = CoreDB()
     build_root = None
 
-    def __new__(cls, *args, **kwargs):
-        if not cls._instance:
-            cls._instance = super(CoreManager, cls).__new__(cls, *args, **kwargs)
-            cls._instance._config = Config()
-            cls._instance.build_root = cls._instance._config.build_root
-        return cls._instance
+    def __init__(self):
+        self._config = Config()
+        self.build_root = self._config.build_root
 
     def load_core(self, file):
         if os.path.exists(file):

--- a/fusesoc/coremanager.py
+++ b/fusesoc/coremanager.py
@@ -122,19 +122,17 @@ class CoreDB(object):
 class CoreManager(object):
     _instance = None
     _cores_root = []
-    _config = None
 
     db = CoreDB()
-    build_root = None
+    config = None
 
-    def __init__(self):
-        self._config = Config()
-        self.build_root = self._config.build_root
+    def __init__(self, config):
+        self.config = config
 
     def load_core(self, file):
         if os.path.exists(file):
             try:
-                core = Core(file, self._config.cache_root, self._config.build_root)
+                core = Core(file, self.config.cache_root, self.config.build_root)
                 self.db.add(core)
             except SyntaxError as e:
                 w = "Parse error. Ignoring file " + file + ": " + e.msg

--- a/fusesoc/coremanager.py
+++ b/fusesoc/coremanager.py
@@ -12,6 +12,7 @@ from simplesat.repository import Repository
 from simplesat.request import Request
 
 from fusesoc.core import Core
+from fusesoc.config import Config
 
 logger = logging.getLogger(__name__)
 
@@ -121,18 +122,22 @@ class CoreDB(object):
 class CoreManager(object):
     _instance = None
     _cores_root = []
+    _config = None
 
     db = CoreDB()
+    build_root = None
 
     def __new__(cls, *args, **kwargs):
         if not cls._instance:
             cls._instance = super(CoreManager, cls).__new__(cls, *args, **kwargs)
+            cls._instance._config = Config()
+            cls._instance.build_root = cls._instance._config.build_root
         return cls._instance
 
     def load_core(self, file):
         if os.path.exists(file):
             try:
-                core = Core(file)
+                core = Core(file, self._config.cache_root, self._config.build_root)
                 self.db.add(core)
             except SyntaxError as e:
                 w = "Parse error. Ignoring file " + file + ": " + e.msg

--- a/fusesoc/main.py
+++ b/fusesoc/main.py
@@ -180,10 +180,10 @@ def run_backend(export, do_configure, do_build, do_run, flags, system, backendar
         exit(1)
     flags['tool'] = tool
     if export:
-        export_root = os.path.join(Config().build_root, core.name.sanitized_name, 'src')
+        export_root = os.path.join(CoreManager().build_root, core.name.sanitized_name, 'src')
     else:
         export_root = None
-    work_root   = os.path.join(Config().build_root,
+    work_root   = os.path.join(CoreManager().build_root,
                                core.name.sanitized_name,
                                core.get_work_root(flags))
     eda_api_file = os.path.join(work_root,
@@ -289,7 +289,7 @@ def run(args):
         logger.debug("Colorful output")
 
     cm = CoreManager()
-    config = Config()
+    config = CoreManager._config
 
     # Get the environment variable for further cores
     env_cores_root = []

--- a/fusesoc/main.py
+++ b/fusesoc/main.py
@@ -89,7 +89,7 @@ def fetch(cm, args):
         logger.error("Failed to fetch '{}': {}".format(core.name, str(e)))
         exit(1)
 
-def init(args):
+def init(cm, args):
     # Fix Python 2.x.
     global input
     try:
@@ -180,10 +180,10 @@ def run_backend(cm, export, do_configure, do_build, do_run, flags, system, backe
         exit(1)
     flags['tool'] = tool
     if export:
-        export_root = os.path.join(cm.build_root, core.name.sanitized_name, 'src')
+        export_root = os.path.join(cm.config.build_root, core.name.sanitized_name, 'src')
     else:
         export_root = None
-    work_root   = os.path.join(cm.build_root,
+    work_root   = os.path.join(cm.config.build_root,
                                core.name.sanitized_name,
                                core.get_work_root(flags))
     eda_api_file = os.path.join(work_root,
@@ -288,8 +288,8 @@ def run(args):
     else:
         logger.debug("Colorful output")
 
-    cm = CoreManager()
-    config = cm._config
+    config = Config()
+    cm = CoreManager(config)
 
     # Get the environment variable for further cores
     env_cores_root = []

--- a/fusesoc/main.py
+++ b/fusesoc/main.py
@@ -315,12 +315,6 @@ def run(args):
     else:
         config.archbits = 64 if platform.architecture()[0] == '64bit' else 32
         logger.debug("Autodetected " + str(config.archbits) + "-bit mode")
-    if sys.platform == "win32":
-        config.cygpath = vars(args)['cygpath']
-        if config.cygpath:
-            logger.debug("Using cygpath translation")
-        else:
-            logger.debug("Using native Windows paths")
     # Run the function
     args.func(cm, args)
 
@@ -338,7 +332,6 @@ def main():
     parser.add_argument('--64', help='Force 64 bit mode for invoked tools', action='store_true')
     parser.add_argument('--monochrome', help='Don\'t use color for messages', action='store_true')
     parser.add_argument('--verbose', help='More info messages', action='store_true')
-    parser.add_argument('--cygpath', help='Use POSIX paths on Windows (no effect on POSIX systems)', action='store_true')
 
     # build subparser
     parser_build = subparsers.add_parser('build', help='Build an FPGA load module')

--- a/fusesoc/provider/opencores.py
+++ b/fusesoc/provider/opencores.py
@@ -2,7 +2,7 @@ import logging
 import sys
 
 from fusesoc.provider.provider import Provider
-from fusesoc.utils import Launcher, cygpath
+from fusesoc.utils import Launcher, cygpath, is_mingw
 from fusesoc.config import Config
 
 logger = logging.getLogger(__name__)
@@ -19,7 +19,8 @@ class Opencores(Provider):
         revision_number  = self.config.get('revision')
         logger.info("Downloading " + repo_name + " from OpenCores")
 
-        if sys.platform == "win32" and Config().cygpath:
+        if is_mingw():
+            logger.debug("Using cygpath translation")
             local_dir = cygpath(local_dir)
 
         Launcher('svn', ['co', '-q', '--no-auth-cache',

--- a/fusesoc/utils.py
+++ b/fusesoc/utils.py
@@ -47,6 +47,11 @@ class Launcher:
     def __str__(self):
         return ' '.join([self.cmd] + self.args)
 
+def is_mingw():
+    if sys.platform == "msys":
+        return True
+    return (sys.platform == "win32" and "GCC" in sys.version)
+
 def cygpath(win_path):
     path = subprocess.check_output(["cygpath", "-u", win_path])
     return path.decode('ascii').strip()

--- a/tests/test_capi1.py
+++ b/tests/test_capi1.py
@@ -4,7 +4,7 @@ import pytest
 
 from fusesoc.core import Core
 
-from test_common import get_core
+from test_common import get_core, cache_root, build_root
 def compare_fileset(fileset, name, files):
     assert name == fileset.name
     for i in range(len(files)):
@@ -41,7 +41,7 @@ def test_core_parsing():
     import sys
     if sys.version_info[0] > 2:
         with pytest.raises(SyntaxError) as e:
-            core = Core("tests/cores/misc/duplicateoptions.core")
+            core = Core("tests/cores/misc/duplicateoptions.core", cache_root, build_root)
         assert "option 'file_type' in section 'fileset dummy' already exists" in str(e.value)
 
 def test_get_scripts():
@@ -95,7 +95,7 @@ def test_get_toplevel():
     filename = os.path.join(os.path.dirname(__file__),
                             __name__,
                             "atlys.core")
-    core = Core(filename)
+    core = Core(filename, cache_root, build_root)
     assert 'orpsoc_tb'  == core.get_toplevel({'tool' : 'icarus'})
     assert 'orpsoc_tb'  == core.get_toplevel({'tool' : 'icarus', 'testbench' : None})
     assert 'tb'         == core.get_toplevel({'tool' : 'icarus', 'testbench' : 'tb'})
@@ -103,7 +103,7 @@ def test_get_toplevel():
     filename = os.path.join(os.path.dirname(__file__),
                             __name__,
                             "sockit.core")
-    core = Core(filename)
+    core = Core(filename, cache_root, build_root)
     assert 'dummy_tb'   == core.get_toplevel({'tool' : 'icarus'})
     assert 'dummy_tb'   == core.get_toplevel({'tool' : 'icarus', 'testbench' : None})
     assert 'tb'         == core.get_toplevel({'tool' : 'icarus', 'testbench' : 'tb'})
@@ -113,7 +113,7 @@ def test_icestorm():
     filename = os.path.join(os.path.dirname(__file__),
                             __name__,
                             "c3demo.core")
-    core = Core(filename)
+    core = Core(filename, cache_root, build_root)
     assert len(core.file_sets) == 3
     compare_fileset(core.file_sets[0], 'rtl_files', ['c3demo.v', 'ledpanel.v','picorv32.v'])
     compare_fileset(core.file_sets[1], 'tb_files' , ['firmware.hex', '$YOSYS_DAT_DIR/ice40/cells_sim.v', 'testbench.v'])
@@ -131,7 +131,7 @@ def test_ise():
     filename = os.path.join(os.path.dirname(__file__),
                             __name__,
                             "atlys.core")
-    core = Core(filename)
+    core = Core(filename, cache_root, build_root)
 
     #Check filesets
     assert len(core.file_sets) == 4
@@ -157,7 +157,7 @@ def test_quartus():
     filename = os.path.join(os.path.dirname(__file__),
                             __name__,
                             "sockit.core")
-    core = Core(filename)
+    core = Core(filename, cache_root, build_root)
 
     #Check filesets
     assert len(core.file_sets) == 4
@@ -185,12 +185,12 @@ def test_simulator():
     filename = os.path.join(os.path.dirname(__file__),
                             __name__,
                             "c3demo.core")
-    core = Core(filename)
+    core = Core(filename, cache_root, build_root)
     assert core.simulator['toplevel'] == 'testbench'
 
     #Implicit toplevel
     filename = os.path.join(os.path.dirname(__file__),
                             __name__,
                             "atlys.core")
-    core = Core(filename)
+    core = Core(filename, cache_root, build_root)
     assert core.simulator['toplevel'] == 'orpsoc_tb'

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -1,6 +1,12 @@
+import os
+
+tests_dir = os.path.dirname(__file__)
+build_root = os.path.join(tests_dir, 'build')
+cache_root = os.path.join(tests_dir, 'cache')
+cores_root = os.path.join(tests_dir, 'cores')
+
 def compare_file(ref_dir, work_root, name):
     import difflib
-    import os
     reference_file = os.path.join(ref_dir, name)
     generated_file = os.path.join(work_root, name)
 
@@ -12,7 +18,6 @@ def compare_file(ref_dir, work_root, name):
 
 def compare_files(ref_dir, work_root, files):
     import difflib
-    import os
 
     for f in files:
         reference_file = os.path.join(ref_dir, f)
@@ -24,18 +29,13 @@ def compare_files(ref_dir, work_root, files):
             assert fref.read() == fgen.read(), f
 
 def get_core(core):
-    import os
-    from fusesoc.config import Config
     from fusesoc.coremanager import CoreManager
     from fusesoc.main import _get_core
 
-    tests_dir = os.path.dirname(__file__)
-
-    Config().build_root = os.path.join(tests_dir, 'build')
-    Config().cache_root = os.path.join(tests_dir, 'cache')
-    cores_root = os.path.join(tests_dir, 'cores')
-
+    CoreManager()._config.build_root = build_root
+    CoreManager()._config.cache_root = cache_root
     CoreManager().add_cores_root(cores_root)
+    
     return _get_core(core)
 
 def get_sim(sim, core, export=False):
@@ -52,15 +52,14 @@ def get_backend(core, flags, export):
     import os.path
     import tempfile
     import yaml
-    from fusesoc.config import Config
     from fusesoc.coremanager import CoreManager
     from fusesoc.main import _import
 
     if export:
-        export_root = os.path.join(Config().build_root, core.name.sanitized_name, 'src')
+        export_root = os.path.join(build_root, core.name.sanitized_name, 'src')
     else:
         export_root = None
-    work_root   = os.path.join(Config().build_root,
+    work_root   = os.path.join(build_root,
                                core.name.sanitized_name,
                                core.get_work_root(flags))
     eda_api = CoreManager().setup(core.name, flags, work_root, export_root)

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -32,11 +32,12 @@ def get_core(core):
     from fusesoc.coremanager import CoreManager
     from fusesoc.main import _get_core
 
-    CoreManager()._config.build_root = build_root
-    CoreManager()._config.cache_root = cache_root
-    CoreManager().add_cores_root(cores_root)
+    cm = CoreManager()
+    cm._config.build_root = build_root
+    cm._config.cache_root = cache_root
+    cm.add_cores_root(cores_root)
     
-    return _get_core(core)
+    return _get_core(cm, core)
 
 def get_sim(sim, core, export=False):
     flags = {'target' : 'sim',

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -30,11 +30,13 @@ def compare_files(ref_dir, work_root, files):
 
 def get_core(core):
     from fusesoc.coremanager import CoreManager
+    from fusesoc.config import Config
     from fusesoc.main import _get_core
 
-    cm = CoreManager()
-    cm._config.build_root = build_root
-    cm._config.cache_root = cache_root
+    config = Config()
+    config.build_root = build_root
+    config.cache_root = cache_root
+    cm = CoreManager(config)
     cm.add_cores_root(cores_root)
     
     return _get_core(cm, core)
@@ -54,6 +56,7 @@ def get_backend(core, flags, export):
     import tempfile
     import yaml
     from fusesoc.coremanager import CoreManager
+    from fusesoc.config import Config
     from fusesoc.main import _import
 
     if export:
@@ -63,7 +66,7 @@ def get_backend(core, flags, export):
     work_root   = os.path.join(build_root,
                                core.name.sanitized_name,
                                core.get_work_root(flags))
-    eda_api = CoreManager().setup(core.name, flags, work_root, export_root)
+    eda_api = CoreManager(Config()).setup(core.name, flags, work_root, export_root)
 
     (h, eda_api_file) = tempfile.mkstemp()
     with open(eda_api_file,'w') as f:

--- a/tests/test_coremanager.py
+++ b/tests/test_coremanager.py
@@ -3,6 +3,7 @@ import pytest
 import shutil
 
 from fusesoc.coremanager import CoreManager
+from fusesoc.config import Config
 from test_common import get_core
 
 def test_copyto():
@@ -24,7 +25,7 @@ def test_copyto():
     else:
         os.makedirs(work_root)
 
-    eda_api = CoreManager().setup(core.name, flags, work_root, None)
+    eda_api = CoreManager(Config()).setup(core.name, flags, work_root, None)
 
     assert eda_api['files'] == [{'file_type': 'user',
                                  'logical_name': '',

--- a/tests/test_edatool.py
+++ b/tests/test_edatool.py
@@ -2,7 +2,7 @@ import os
 import shutil
 import pytest
 
-from test_common import get_core, get_sim
+from test_common import get_core, get_sim, build_root
 
 tests_dir = os.path.dirname(__file__)
 core      = get_core("wb_intercon")
@@ -10,8 +10,7 @@ backend   = get_sim('icarus', core, export=True)
 ref_dir   = os.path.join(tests_dir, __name__)
 
 def test_edatool():
-    from fusesoc.config import Config
-    export_root = os.path.join(Config().build_root, core.name.sanitized_name, 'src')
+    export_root = os.path.join(build_root, core.name.sanitized_name, 'src')
     backend.configure([])
     for f in [
             'verilog_utils_0/verilog_utils.vh',

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,6 +1,7 @@
 import pytest
 
 from fusesoc.main import sim
+from fusesoc.coremanager import CoreManager
 
 def test_sim(capsys):
     class Args():
@@ -17,7 +18,7 @@ def test_sim(capsys):
 
     args = Args(system="wb_common")
     with pytest.raises(SystemExit):
-        sim(args)
+        sim(CoreManager(), args)
     out, err = capsys.readouterr()
     assert out == ""
     #Workaround since this test fails with Travis on Python2.7. No idea why

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -2,6 +2,7 @@ import pytest
 
 from fusesoc.main import sim
 from fusesoc.coremanager import CoreManager
+from fusesoc.config import Config
 
 def test_sim(capsys):
     class Args():
@@ -18,7 +19,7 @@ def test_sim(capsys):
 
     args = Args(system="wb_common")
     with pytest.raises(SystemExit):
-        sim(CoreManager(), args)
+        sim(CoreManager(Config()), args)
     out, err = capsys.readouterr()
     assert out == ""
     #Workaround since this test fails with Travis on Python2.7. No idea why


### PR DESCRIPTION
This pull request refactors the Config and CoreManager classes so they are no longer singletons, and are instead passed to the functions and objects which need them. This is intended to make testing and future development easier.

I might have gone a little overboard here - if you wanted CoreManager to remain a singleton, then only the first two commits are needed.