### PR TITLE
Bug fix: Remove class variables from CoreManager class

### DIFF
--- a/fusesoc/coremanager.py
+++ b/fusesoc/coremanager.py
@@ -120,13 +120,11 @@ class CoreDB(object):
 
 class CoreManager(object):
     _instance = None
-    _cores_root = []
-
-    db = CoreDB()
-    config = None
 
     def __init__(self, config):
         self.config = config
+        self._cores_root = []
+        self.db = CoreDB()
 
     def load_core(self, file):
         if os.path.exists(file):

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -5,6 +5,15 @@ build_root = os.path.join(tests_dir, 'build')
 cache_root = os.path.join(tests_dir, 'cache')
 cores_root = os.path.join(tests_dir, 'cores')
 
+from fusesoc.config import Config
+from fusesoc.coremanager import CoreManager
+
+config = Config()
+config.build_root = build_root
+config.cache_root = cache_root
+common_cm = CoreManager(config)
+common_cm.add_cores_root(cores_root)
+
 def compare_file(ref_dir, work_root, name):
     import difflib
     reference_file = os.path.join(ref_dir, name)
@@ -29,17 +38,9 @@ def compare_files(ref_dir, work_root, files):
             assert fref.read() == fgen.read(), f
 
 def get_core(core):
-    from fusesoc.coremanager import CoreManager
-    from fusesoc.config import Config
     from fusesoc.main import _get_core
-
-    config = Config()
-    config.build_root = build_root
-    config.cache_root = cache_root
-    cm = CoreManager(config)
-    cm.add_cores_root(cores_root)
     
-    return _get_core(cm, core)
+    return _get_core(common_cm, core)
 
 def get_sim(sim, core, export=False):
     flags = {'target' : 'sim',
@@ -55,8 +56,6 @@ def get_backend(core, flags, export):
     import os.path
     import tempfile
     import yaml
-    from fusesoc.coremanager import CoreManager
-    from fusesoc.config import Config
     from fusesoc.main import _import
 
     if export:
@@ -66,7 +65,7 @@ def get_backend(core, flags, export):
     work_root   = os.path.join(build_root,
                                core.name.sanitized_name,
                                core.get_work_root(flags))
-    eda_api = CoreManager(Config()).setup(core.name, flags, work_root, export_root)
+    eda_api = common_cm.setup(core.name, flags, work_root, export_root)
 
     (h, eda_api_file) = tempfile.mkstemp()
     with open(eda_api_file,'w') as f:

--- a/tests/test_coremanager.py
+++ b/tests/test_coremanager.py
@@ -4,7 +4,7 @@ import shutil
 
 from fusesoc.coremanager import CoreManager
 from fusesoc.config import Config
-from test_common import get_core
+from test_common import get_core, common_cm
 
 def test_copyto():
     tests_dir = os.path.dirname(__file__)
@@ -25,7 +25,7 @@ def test_copyto():
     else:
         os.makedirs(work_root)
 
-    eda_api = CoreManager(Config()).setup(core.name, flags, work_root, None)
+    eda_api = common_cm.setup(core.name, flags, work_root, None)
 
     assert eda_api['files'] == [{'file_type': 'user',
                                  'logical_name': '',

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -4,6 +4,8 @@ from fusesoc.main import sim
 from fusesoc.coremanager import CoreManager
 from fusesoc.config import Config
 
+from test_common import common_cm
+
 def test_sim(capsys):
     class Args():
         sim = None
@@ -19,7 +21,7 @@ def test_sim(capsys):
 
     args = Args(system="wb_common")
     with pytest.raises(SystemExit):
-        sim(CoreManager(Config()), args)
+        sim(common_cm, args)
     out, err = capsys.readouterr()
     assert out == ""
     #Workaround since this test fails with Travis on Python2.7. No idea why


### PR DESCRIPTION
I messed up when de-singleton-ing the CoreManager class, leaving several variables as class variables instead of instance variables.

This patch corrects that oversight and also creates a "common_cm" CoreManager in test_common.py so that all the existing tests can easily get the "default" test CoreManager.