### PR TITLE
Add 'library' concept to config files

### DIFF
--- a/fusesoc/config.py
+++ b/fusesoc/config.py
@@ -13,23 +13,34 @@ logger = logging.getLogger(__name__)
 class Config(object):
     archbits = 0
 
-    def __init__(self):
+    def __init__(self, path=None, file=None):
         #TODO: Add option to load custom config file
         self.build_root = None
         self.cache_root = None
         self.cores_root = []
         self.systems_root = None
 
-        xdg_config_home = os.environ.get('XDG_CONFIG_HOME') or \
-                          os.path.join(os.path.expanduser('~'), '.config')
         config = configparser.SafeConfigParser()
-        config_files = ['/etc/fusesoc/fusesoc.conf',
+        if file is None:
+            if path is None:
+                xdg_config_home = os.environ.get('XDG_CONFIG_HOME') or \
+                          os.path.join(os.path.expanduser('~'), '.config')
+                config_files = ['/etc/fusesoc/fusesoc.conf',
                         os.path.join(xdg_config_home, 'fusesoc','fusesoc.conf'),
                         'fusesoc.conf']
+            else:
+                config_files = [path]
 
-        logger.debug('Looking for config files from ' + ':'.join(config_files))
-        files_read = config.read(config_files)
-        logger.debug('Found config files in ' + ':'.join(files_read))
+            logger.debug('Looking for config files from ' + ':'.join(config_files))
+            files_read = config.read(config_files)
+            logger.debug('Found config files in ' + ':'.join(files_read))
+        else:
+            logger.debug('Using supplied config file')
+            if sys.version[0] == '2':
+                config.readfp(file)
+            else:
+                config.read_file(file)
+            file.seek(0)
 
         for item in ['build_root', 'cache_root', 'systems_root']:
             try:

--- a/fusesoc/config.py
+++ b/fusesoc/config.py
@@ -36,7 +36,8 @@ class Config(object):
             logger.debug('Looking for config files from ' + ':'.join(config_files))
             files_read = config.read(config_files)
             logger.debug('Found config files in ' + ':'.join(files_read))
-            self._path = files_read[-1]
+            if files_read:
+                self._path = files_read[-1]
         else:
             logger.debug('Using supplied config file')
             if sys.version[0] == '2':
@@ -118,6 +119,9 @@ class Config(object):
 
     def add_library(self, name, library):
         from fusesoc.utils import Launcher
+        if not hasattr(self, '_path'):
+            logger.error("No FuseSoC config file found - can't add library")
+            exit(1)
         section_name = 'library.' + name
 
         config = configparser.SafeConfigParser()

--- a/fusesoc/config.py
+++ b/fusesoc/config.py
@@ -66,7 +66,7 @@ class Config(object):
             self.cache_root = os.path.join(xdg_cache_home, 'fusesoc')
             if not os.path.exists(self.cache_root):
                 os.makedirs(self.cache_root)
-        if self.cores_root is None and os.path.exists('cores'):
+        if not self.cores_root and os.path.exists('cores'):
             self.cores_root   = [os.path.abspath('cores')]
         if self.systems_root is None and os.path.exists('systems'):
             self.systems_root = os.path.abspath('systems')

--- a/fusesoc/coremanager.py
+++ b/fusesoc/coremanager.py
@@ -120,13 +120,11 @@ class CoreDB(object):
 
 class CoreManager(object):
     _instance = None
-    _cores_root = []
-
-    db = CoreDB()
-    config = None
 
     def __init__(self, config):
         self.config = config
+        self._cores_root = []
+        self.db = CoreDB()
 
     def load_core(self, file):
         if os.path.exists(file):

--- a/fusesoc/main.py
+++ b/fusesoc/main.py
@@ -308,6 +308,13 @@ def run(args):
             cm.add_cores_root(cores_root)
         except (RuntimeError, IOError) as e:
             logger.warning("Failed to register cores root '{}'".format(str(e)))
+
+    for library in config.libraries.values():
+        try:
+            cm.add_cores_root(library['location'])
+        except (RuntimeError, IOError) as e:
+            logger.warning("Failed to register cores root '{}'".format(str(e)))
+
     # Process global options
     if vars(args)['32']:
         config.archbits = 32

--- a/fusesoc/main.py
+++ b/fusesoc/main.py
@@ -259,6 +259,9 @@ def sim(cm, args):
 def update(cm, args):
     libraries = args.libraries
     for root in cm.get_cores_root():
+        if not root in cm.config.cores_root:
+            # This is a library - handled differently
+            continue
         if os.path.exists(root) and (not libraries or root in libraries):
             args = ['-C', root,
                     'config', '--get', 'remote.origin.url']
@@ -269,6 +272,18 @@ def update(cm, args):
                     logger.info("Updating '{}'".format(root))
                     args = ['-C', root, 'pull']
                     Launcher('git', args).run()
+            except subprocess.CalledProcessError:
+                pass
+
+    for (name, library) in cm.config.libraries.items():
+        if os.path.exists(library['location']) and \
+                (name in libraries or \
+                library['location'] in libraries or \
+                library['auto-sync']):
+            logger.info("Updating '{}'".format(name))
+            args = ['-C', library['location'], 'pull']
+            try:
+                Launcher('git', args).run()
             except subprocess.CalledProcessError:
                 pass
 

--- a/fusesoc/main.py
+++ b/fusesoc/main.py
@@ -144,6 +144,23 @@ def list_paths(cm, args):
     cores_root = cm.get_cores_root()
     print("\n".join(cores_root))
 
+def add_library(cm, args):
+    library = {}
+    name = args.name
+    library['sync-uri'] = vars(args)['sync-uri']
+    if args.location:
+        library['location'] = args.location
+    if args.no_auto_sync:
+        library['auto-sync'] = False
+
+    if args.config:
+        config = Config(file=args.config)
+    else:
+        config = Config()
+
+    config.add_library(name, library)
+
+
 def list_cores(cm, args):
     cores = cm.get_cores()
     print("\nAvailable cores:\n")
@@ -401,6 +418,18 @@ def main():
     # list-paths subparser
     parser_list_paths = subparsers.add_parser('list-paths', help='Display the search order for core root paths')
     parser_list_paths.set_defaults(func=list_paths)
+
+    # library subparser
+    parser_library = subparsers.add_parser('library', help='Subcommands for dealing with library management')
+    library_subparsers = parser_library.add_subparsers()
+
+    # library add subparser
+    parser_library_add = library_subparsers.add_parser('add', help='Add new library to fusesoc.conf')
+    parser_library_add.add_argument('name', help='A friendly name  for the library')
+    parser_library_add.add_argument('sync-uri', help='The URI source for the library')
+    parser_library_add.add_argument('--location', help='The location to store the library into (defaults to $XDG_DATA_HOME/[name])')
+    parser_library_add.add_argument('--no-auto-sync', action='store_true', help='Disable automatic updates of the library')
+    parser_library_add.set_defaults(func=add_library)
 
     # sim subparser
     parser_sim = subparsers.add_parser('sim', help='Setup and run a simulation')

--- a/fusesoc/main.py
+++ b/fusesoc/main.py
@@ -257,8 +257,9 @@ def sim(cm, args):
                 flags, args.system, args.backendargs)
 
 def update(cm, args):
+    libraries = args.libraries
     for root in cm.get_cores_root():
-        if os.path.exists(root):
+        if os.path.exists(root) and (not libraries or root in libraries):
             args = ['-C', root,
                     'config', '--get', 'remote.origin.url']
             repo_root = ""
@@ -402,6 +403,7 @@ def main():
 
     # update subparser
     parser_update = subparsers.add_parser('update', help='Update the FuseSoC core libraries')
+    parser_update.add_argument('libraries', nargs='*', help='The libraries (or core roots) to update (defaults to all)')
     parser_update.set_defaults(func=update)
 
     parsed_args = parser.parse_args()

--- a/fusesoc/main.py
+++ b/fusesoc/main.py
@@ -288,7 +288,10 @@ def run(args):
     else:
         logger.debug("Colorful output")
 
-    config = Config()
+    if args.config:
+        config = Config(file=args.config)
+    else:
+        config = Config()
     cm = CoreManager(config)
 
     # Get the environment variable for further cores
@@ -328,6 +331,7 @@ def main():
 
     # Global options
     parser.add_argument('--cores-root', help='Add additional directories containing cores', action='append')
+    parser.add_argument('--config', help='Specify the config file to use', type=argparse.FileType('r'))
     parser.add_argument('--32', help='Force 32 bit mode for invoked tools', action='store_true')
     parser.add_argument('--64', help='Force 64 bit mode for invoked tools', action='store_true')
     parser.add_argument('--monochrome', help='Don\'t use color for messages', action='store_true')

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -4,6 +4,7 @@ tests_dir = os.path.dirname(__file__)
 build_root = os.path.join(tests_dir, 'build')
 cache_root = os.path.join(tests_dir, 'cache')
 cores_root = os.path.join(tests_dir, 'cores')
+library_root = os.path.join(tests_dir, 'libraries')
 
 from fusesoc.config import Config
 from fusesoc.coremanager import CoreManager

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -5,6 +5,15 @@ build_root = os.path.join(tests_dir, 'build')
 cache_root = os.path.join(tests_dir, 'cache')
 cores_root = os.path.join(tests_dir, 'cores')
 
+from fusesoc.config import Config
+from fusesoc.coremanager import CoreManager
+
+config = Config()
+config.build_root = build_root
+config.cache_root = cache_root
+common_cm = CoreManager(config)
+common_cm.add_cores_root(cores_root)
+
 def compare_file(ref_dir, work_root, name):
     import difflib
     reference_file = os.path.join(ref_dir, name)
@@ -29,17 +38,9 @@ def compare_files(ref_dir, work_root, files):
             assert fref.read() == fgen.read(), f
 
 def get_core(core):
-    from fusesoc.coremanager import CoreManager
-    from fusesoc.config import Config
     from fusesoc.main import _get_core
-
-    config = Config()
-    config.build_root = build_root
-    config.cache_root = cache_root
-    cm = CoreManager(config)
-    cm.add_cores_root(cores_root)
     
-    return _get_core(cm, core)
+    return _get_core(common_cm, core)
 
 def get_sim(sim, core, export=False):
     flags = {'target' : 'sim',
@@ -55,8 +56,6 @@ def get_backend(core, flags, export):
     import os.path
     import tempfile
     import yaml
-    from fusesoc.coremanager import CoreManager
-    from fusesoc.config import Config
     from fusesoc.main import _import
 
     if export:
@@ -66,7 +65,7 @@ def get_backend(core, flags, export):
     work_root   = os.path.join(build_root,
                                core.name.sanitized_name,
                                core.get_work_root(flags))
-    eda_api = CoreManager(Config()).setup(core.name, flags, work_root, export_root)
+    eda_api = common_cm.setup(core.name, flags, work_root, export_root)
 
     (h, eda_api_file) = tempfile.mkstemp()
     with open(eda_api_file,'w') as f:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -19,7 +19,7 @@ sync-uri = https://github.com/fusesoc/fusesoc-cores
 """
 
 def test_config_file():
-    tcf = tempfile.TemporaryFile(mode="w+")
+    tcf = tempfile.NamedTemporaryFile(mode="w+")
     tcf.write(EXAMPLE_CONFIG.format(
             build_root = build_root,
             cache_root = cache_root,
@@ -34,7 +34,7 @@ def test_config_file():
     assert conf.build_root == build_root
 
 def test_config_path():
-    tcf = tempfile.TemporaryFile(mode="w+")
+    tcf = tempfile.NamedTemporaryFile(mode="w+")
     tcf.write(EXAMPLE_CONFIG.format(
             build_root = build_root,
             cache_root = cache_root,
@@ -49,7 +49,7 @@ def test_config_path():
     assert conf.library_root == library_root
 
 def test_config_failure():
-    tcf = tempfile.TemporaryFile(mode="w+")
+    tcf = tempfile.NamedTemporaryFile(mode="w+")
     tcf.write(EXAMPLE_CONFIG.format(
             build_root = build_root,
             cache_root = cache_root,
@@ -59,12 +59,12 @@ def test_config_failure():
         )
     tcf.seek(0)
 
-    conf = Config(path=tcf.name)
+    conf = Config(file=tcf)
 
     assert not conf.cores_root == cores_root
 
 def test_config_libraries():
-    tcf = tempfile.TemporaryFile(mode="w+")
+    tcf = tempfile.NamedTemporaryFile(mode="w+")
     tcf.write(EXAMPLE_CONFIG.format(
             build_root = build_root,
             cache_root = cache_root,
@@ -74,7 +74,7 @@ def test_config_libraries():
         )
     tcf.seek(0)
 
-    conf = Config(path=tcf.name)
+    conf = Config(file=tcf)
 
     assert conf.libraries['test_lib']['location'] == os.path.join(library_root, 'test_lib')
     assert conf.libraries['test_lib']['sync-uri'] == 'https://github.com/fusesoc/fusesoc-cores'

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,55 @@
+import tempfile
+
+from fusesoc.config import Config
+
+from test_common import cores_root, build_root, cache_root
+
+EXAMPLE_CONFIG = """
+[main]
+build_root = {build_root}
+cache_root = {cache_root}
+cores_root = {cores_root}
+"""
+
+def test_config_file():
+    tcf = tempfile.TemporaryFile(mode="w+")
+    tcf.write(EXAMPLE_CONFIG.format(
+            build_root = build_root,
+            cache_root = cache_root,
+            cores_root = cores_root
+            )
+        )
+    tcf.seek(0)
+    
+    conf = Config(file=tcf)
+    
+    assert conf.build_root == build_root
+
+def test_config_path():
+    tcf = tempfile.TemporaryFile(mode="w+")
+    tcf.write(EXAMPLE_CONFIG.format(
+            build_root = build_root,
+            cache_root = cache_root,
+            cores_root = cores_root
+            )
+        )
+    tcf.seek(0)
+    
+    conf = Config(path=tcf.name)
+    
+    assert conf.cache_root == cache_root
+
+def test_config_failure():
+    tcf = tempfile.TemporaryFile(mode="w+")
+    tcf.write(EXAMPLE_CONFIG.format(
+            build_root = build_root,
+            cache_root = cache_root,
+            cores_root = "INCORRECT"
+            )
+        )
+    tcf.seek(0)
+    
+    conf = Config(path=tcf.name)
+    
+    assert not conf.cores_root == cores_root
+

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,14 +1,21 @@
 import tempfile
+import os.path
 
 from fusesoc.config import Config
 
-from test_common import cores_root, build_root, cache_root
+from test_common import cores_root, build_root, cache_root, library_root
 
 EXAMPLE_CONFIG = """
 [main]
 build_root = {build_root}
 cache_root = {cache_root}
 cores_root = {cores_root}
+library_root = {library_root}
+
+[library.test_lib]
+location = {library_root}/test_lib
+auto-sync = false
+sync-uri = https://github.com/fusesoc/fusesoc-cores
 """
 
 def test_config_file():
@@ -16,13 +23,14 @@ def test_config_file():
     tcf.write(EXAMPLE_CONFIG.format(
             build_root = build_root,
             cache_root = cache_root,
-            cores_root = cores_root
+            cores_root = cores_root,
+            library_root = library_root
             )
         )
     tcf.seek(0)
-    
+
     conf = Config(file=tcf)
-    
+
     assert conf.build_root == build_root
 
 def test_config_path():
@@ -30,26 +38,45 @@ def test_config_path():
     tcf.write(EXAMPLE_CONFIG.format(
             build_root = build_root,
             cache_root = cache_root,
-            cores_root = cores_root
+            cores_root = cores_root,
+            library_root = library_root
             )
         )
     tcf.seek(0)
-    
+
     conf = Config(path=tcf.name)
-    
-    assert conf.cache_root == cache_root
+
+    assert conf.library_root == library_root
 
 def test_config_failure():
     tcf = tempfile.TemporaryFile(mode="w+")
     tcf.write(EXAMPLE_CONFIG.format(
             build_root = build_root,
             cache_root = cache_root,
-            cores_root = "INCORRECT"
+            cores_root = "INCORRECT",
+            library_root = library_root
             )
         )
     tcf.seek(0)
-    
+
     conf = Config(path=tcf.name)
-    
+
     assert not conf.cores_root == cores_root
+
+def test_config_libraries():
+    tcf = tempfile.TemporaryFile(mode="w+")
+    tcf.write(EXAMPLE_CONFIG.format(
+            build_root = build_root,
+            cache_root = cache_root,
+            cores_root = cores_root,
+            library_root = library_root
+            )
+        )
+    tcf.seek(0)
+
+    conf = Config(path=tcf.name)
+
+    assert conf.libraries['test_lib']['location'] == os.path.join(library_root, 'test_lib')
+    assert conf.libraries['test_lib']['sync-uri'] == 'https://github.com/fusesoc/fusesoc-cores'
+    assert not conf.libraries['test_lib']['auto-sync']
 

--- a/tests/test_coremanager.py
+++ b/tests/test_coremanager.py
@@ -4,7 +4,7 @@ import shutil
 
 from fusesoc.coremanager import CoreManager
 from fusesoc.config import Config
-from test_common import get_core
+from test_common import get_core, common_cm
 
 def test_copyto():
     tests_dir = os.path.dirname(__file__)
@@ -25,7 +25,7 @@ def test_copyto():
     else:
         os.makedirs(work_root)
 
-    eda_api = CoreManager(Config()).setup(core.name, flags, work_root, None)
+    eda_api = common_cm.setup(core.name, flags, work_root, None)
 
     assert eda_api['files'] == [{'file_type': 'user',
                                  'logical_name': '',

--- a/tests/test_libraries.py
+++ b/tests/test_libraries.py
@@ -1,0 +1,53 @@
+import tempfile
+import os.path
+
+from argparse import Namespace
+
+from fusesoc.config import Config
+from fusesoc.main import run
+
+from test_common import cores_root, build_root, cache_root, library_root
+
+EXAMPLE_CONFIG = """
+[main]
+build_root = {build_root}
+cache_root = {cache_root}
+library_root = {library_root}
+
+[library.test_lib]
+location = {cores_root}
+auto-sync = false
+sync-uri = https://github.com/fusesoc/fusesoc-cores
+"""
+
+def _run_test_util(cm, args):
+    from fusesoc.main import _get_core
+    _get_core(cm, 'mor1kx-generic')
+    _get_core(cm, 'atlys')
+
+def test_library_location():
+    tcf = tempfile.TemporaryFile(mode="w+")
+    tcf.write(EXAMPLE_CONFIG.format(
+            build_root = build_root,
+            cache_root = cache_root,
+            cores_root = cores_root,
+            library_root = library_root
+            )
+        )
+    tcf.seek(0)
+    
+    conf = Config(file=tcf)
+    
+    args = Namespace()
+    
+    # TODO find a better way to set up these defaults
+    args.verbose = False
+    args.monochrome = False
+    args.cores_root = []
+    vars(args)['32'] = False
+    vars(args)['64'] = False
+    
+    args.config = tcf
+    args.func = _run_test_util
+    
+    run(args)

--- a/tests/test_libraries.py
+++ b/tests/test_libraries.py
@@ -1,10 +1,12 @@
 import tempfile
+import shutil
 import os.path
+import logging
+import subprocess
 
 from argparse import Namespace
 
 from fusesoc.config import Config
-from fusesoc.main import run
 
 from test_common import cores_root, build_root, cache_root, library_root
 
@@ -16,9 +18,11 @@ library_root = {library_root}
 
 [library.test_lib]
 location = {cores_root}
-auto-sync = false
-sync-uri = https://github.com/fusesoc/fusesoc-cores
+auto-sync = {auto_sync}
+sync-uri = {sync_uri}
 """
+
+sync_uri = 'https://github.com/fusesoc/fusesoc-cores'
 
 def _run_test_util(cm, args):
     from fusesoc.main import _get_core
@@ -26,28 +30,96 @@ def _run_test_util(cm, args):
     _get_core(cm, 'atlys')
 
 def test_library_location():
+    from fusesoc.main import run
+
     tcf = tempfile.TemporaryFile(mode="w+")
     tcf.write(EXAMPLE_CONFIG.format(
             build_root = build_root,
             cache_root = cache_root,
             cores_root = cores_root,
-            library_root = library_root
+            library_root = library_root,
+            auto_sync = 'false',
+            sync_uri = sync_uri
             )
         )
     tcf.seek(0)
-    
+
     conf = Config(file=tcf)
-    
+
     args = Namespace()
-    
+
     # TODO find a better way to set up these defaults
     args.verbose = False
     args.monochrome = False
     args.cores_root = []
     vars(args)['32'] = False
     vars(args)['64'] = False
-    
+
     args.config = tcf
     args.func = _run_test_util
-    
+
     run(args)
+
+def test_library_update(caplog):
+    from fusesoc.main import update, run
+
+    clone_target = tempfile.mkdtemp()
+
+    try:
+        subprocess.call(['git', 'clone', sync_uri, clone_target])
+
+        tcf = tempfile.TemporaryFile(mode="w+")
+        tcf.write(EXAMPLE_CONFIG.format(
+                build_root = build_root,
+                cache_root = cache_root,
+                cores_root = clone_target,
+                library_root = library_root,
+                auto_sync = 'false',
+                sync_uri = sync_uri
+                )
+            )
+        tcf.seek(0)
+
+        conf = Config(file=tcf)
+
+        args = Namespace()
+
+        # TODO find a better way to set up these defaults
+        args.verbose = False
+        args.monochrome = False
+        args.cores_root = []
+        vars(args)['32'] = False
+        vars(args)['64'] = False
+
+        args.config = tcf
+        args.libraries = []
+        args.func = update
+
+        with caplog.at_level(logging.INFO):
+            run(args)
+
+        assert not "Updating 'test_lib'" in caplog.text
+
+        caplog.clear()
+
+        args.libraries = ['test_lib']
+
+        with caplog.at_level(logging.INFO):
+            run(args)
+
+        assert "Updating 'test_lib'" in caplog.text
+
+        caplog.clear()
+
+        args.libraries = []
+        conf.libraries['test_lib']['auto-sync'] = True
+
+        with caplog.at_level(logging.INFO):
+            run(args)
+
+        assert "Updating 'test_lib'" in caplog.text
+
+        caplog.clear()
+
+    finally:
+        shutil.rmtree(clone_target)

--- a/tests/test_libraries.py
+++ b/tests/test_libraries.py
@@ -32,7 +32,7 @@ def _run_test_util(cm, args):
 def test_library_location():
     from fusesoc.main import run
 
-    tcf = tempfile.TemporaryFile(mode="w+")
+    tcf = tempfile.NamedTemporaryFile(mode="w+")
     tcf.write(EXAMPLE_CONFIG.format(
             build_root = build_root,
             cache_root = cache_root,
@@ -64,7 +64,7 @@ def test_library_add():
     from fusesoc.main import add_library, run
     from fusesoc.coremanager import CoreManager
 
-    tcf = tempfile.TemporaryFile(mode="w+")
+    tcf = tempfile.NamedTemporaryFile(mode="w+")
 
     conf = Config(file=tcf)
     cm = CoreManager(conf)
@@ -95,7 +95,7 @@ def test_library_update(caplog):
     try:
         subprocess.call(['git', 'clone', sync_uri, clone_target])
 
-        tcf = tempfile.TemporaryFile(mode="w+")
+        tcf = tempfile.NamedTemporaryFile(mode="w+")
         tcf.write(EXAMPLE_CONFIG.format(
                 build_root = build_root,
                 cache_root = cache_root,

--- a/tests/test_libraries.py
+++ b/tests/test_libraries.py
@@ -60,6 +60,33 @@ def test_library_location():
 
     run(args)
 
+def test_library_add():
+    from fusesoc.main import add_library, run
+    from fusesoc.coremanager import CoreManager
+
+    tcf = tempfile.TemporaryFile(mode="w+")
+
+    conf = Config(file=tcf)
+    cm = CoreManager(conf)
+
+    args = Namespace()
+
+    args.name = 'fusesoc-cores'
+    args.location = None
+    args.config = tcf
+    args.no_auto_sync = False
+    vars(args)['sync-uri'] = sync_uri
+
+    add_library(cm, args)
+
+    expected = """[library.fusesoc-cores]
+sync-uri = https://github.com/fusesoc/fusesoc-cores"""
+
+    tcf.seek(0)
+    result = tcf.read().strip()
+
+    assert expected == result
+
 def test_library_update(caplog):
     from fusesoc.main import update, run
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -4,6 +4,8 @@ from fusesoc.main import sim
 from fusesoc.coremanager import CoreManager
 from fusesoc.config import Config
 
+from test_common import common_cm
+
 def test_sim(capsys):
     class Args():
         sim = None
@@ -19,7 +21,7 @@ def test_sim(capsys):
 
     args = Args(system="wb_common")
     with pytest.raises(SystemExit):
-        sim(CoreManager(Config()), args)
+        sim(common_cm, args)
     out, err = capsys.readouterr()
     assert out == ""
     #Workaround since this test fails with Travis on Python2.7. No idea why


### PR DESCRIPTION
This PR adds support for "libraries" as a concept in FuseSoC config files. Libraries are based off of Gentoo's repos.conf. They live in sections of the form [library.name] and (currently) have three properties, two of which are optional.

sync-uri is the URI source of the library. Currently this is assumed to be a Git repo. Required.
location is where to store the "cached" library - essentially, the clone target for the Git repo. It defaults to `$XDG_DATA_HOME/name`.
auto-sync specifies whether the library should be automatically updated by `fusesoc update`. Defaults to `true`. If set to `false`, the library can still be updated by passing its name explicitly to `fusesoc update`.