### PR TITLE
Modelsim changes

### DIFF
--- a/fusesoc/edatools/modelsim.py
+++ b/fusesoc/edatools/modelsim.py
@@ -159,11 +159,14 @@ class Modelsim(Simulator):
                  cwd      = self.work_root,
                  errormsg = "Failed to build simulation model. Log is available in '{}'".format(os.path.join(self.work_root, 'transcript'))).run()
         if self.vpi_modules:
+            f = open(os.path.join(self.work_root, 'vpi_build.log'),'w')
             args = ['all']
             Launcher('make', args,
                      cwd      = self.work_root,
-                     stdout = open(os.path.join(self.work_root, 'vpi_build.log'),'w'),
+                     stdout =  f,
+                     stderr =  f,
                      errormsg = " vpi build failed. log is available in '{}'".format(os.path.join(self.work_root, 'vpi_build.log'))).run()
+            f.close()
 
     def run(self, args):
         self.model_tech = os.getenv('MODEL_TECH')

--- a/tests/test_modelsim/fusesoc_main.tcl
+++ b/tests/test_modelsim/fusesoc_main.tcl
@@ -1,3 +1,2 @@
 do fusesoc_build_rtl.tcl
 do ../../../cores/misc/tcl_file.tcl
-make

--- a/tests/test_modelsim/fusesoc_run.tcl
+++ b/tests/test_modelsim/fusesoc_run.tcl
@@ -1,1 +1,2 @@
 vsim -pli elf-loader_0 orpsoc_tb +plusarg_bool=1 +plusarg_int=42 +plusarg_str=hello -gvlogparam_bool=1 -gvlogparam_int=42 -gvlogparam_str=hello
+run -all

--- a/tests/test_modelsim/run.cmd
+++ b/tests/test_modelsim/run.cmd
@@ -1,1 +1,1 @@
--c -quiet -do fusesoc_run.tcl -do run -all
+-c -quiet -do fusesoc_run.tcl


### PR DESCRIPTION
PR fixes two issues with Modelsim simulation. I tried de2 and de0_nano with an old Modelsim (10.1d)

- Use Launcher to run vpi build instead of fusesoc_main.tcl. vsim tcl seems to have a problem with gcc warnings having format specifier (0x%08X)

- Moved 'run -all' to fusesoc_run.tcl to make sure vsim loads simulation top first. otherwise, it passes '-do run -all' first and fails to load top

That said, i am using 6 years old Modelsim and i need to check if they are fixed with new releases But these changes should work with any release.