### PR TITLE
Support for using 'sync-type' to determine library provider

### DIFF
--- a/fusesoc/capi1/core.py
+++ b/fusesoc/capi1/core.py
@@ -120,9 +120,7 @@ class Core:
             provider_name = items.get('name')
             if provider_name is None:
                 raise RuntimeError('Missing "name" in section [provider]')
-            provider_module = importlib.import_module(
-                'fusesoc.provider.%s' % provider_name)
-            self.provider = provider_module.PROVIDER_CLASS(
+            self.provider = utils._import(provider_name, 'provider')(
                 items, self.core_root, cache_root)
         if self.provider:
             self.files_root = self.provider.files_root

--- a/fusesoc/capi2/core.py
+++ b/fusesoc/capi2/core.py
@@ -94,9 +94,7 @@ class Provider(object):
         provider_name = args[0]['name']
         if provider_name is None:
             raise RuntimeError('Missing "name" in section [provider]')
-        provider_module = importlib.import_module(
-            'fusesoc.provider.%s' % provider_name)
-        return provider_module.PROVIDER_CLASS(args[0],
+        return utils._import(provider_name, 'provider')(args[0],
                                               "FIXME: core_root is used by local providers",
                                              "FIXME: cache_root can be set in fetch call")
 

--- a/fusesoc/config.py
+++ b/fusesoc/config.py
@@ -123,7 +123,7 @@ class Config(object):
         logger.debug('library_root='+self.library_root)
 
     def add_library(self, name, library):
-        from fusesoc.utils import Launcher
+        from fusesoc.utils import Launcher, _import
         if not hasattr(self, '_path'):
             raise RuntimeError("No FuseSoC config file found - can't add library")
         section_name = 'library.' + name
@@ -162,12 +162,11 @@ class Config(object):
         self.libraries[name] = library
 
         try:
-            provider_module = importlib.import_module(
-                'fusesoc.provider.%s' % library['sync-type'])
+            provider = _import(library['sync-type'], 'provider')
         except ImportError as e:
             raise RuntimeError("Invalid sync-type '{}'".format(library['sync-type']))
 
-        provider_module.PROVIDER_CLASS.init_library(library)
+        provider.init_library(library)
 
         with open(self._path, 'w') as conf_file:
             config.write(conf_file)

--- a/fusesoc/provider/coregen.py
+++ b/fusesoc/provider/coregen.py
@@ -33,5 +33,3 @@ class Coregen(Provider):
                 '-b', script_file,
                 '-p', project_file]
         Launcher('coregen', args, cwd=local_dir).run()
-
-PROVIDER_CLASS = Coregen

--- a/fusesoc/provider/git.py
+++ b/fusesoc/provider/git.py
@@ -1,11 +1,30 @@
 import logging
 import shutil
+import os.path
+import subprocess
 from fusesoc.provider.provider import Provider
 from fusesoc.utils import Launcher
 
 logger = logging.getLogger(__name__)
 
 class Git(Provider):
+    @staticmethod
+    def init_library(library):
+        logger.info("Cloning library into {}".format(library['location']))
+        git_args = ['clone', library['sync-uri'], library['location']]
+        try:
+            Launcher('git', git_args).run()
+        except subprocess.CalledProcessError as e:
+            raise RuntimeError(str(e))
+
+    @staticmethod
+    def update_library(library):
+        logger.info("Updating library {}".format(library['location']))
+        git_args = ['-C', library['location'], 'pull']
+        try:
+            Launcher('git', git_args).run()
+        except subprocess.CalledProcessError as e:
+            raise RuntimeError(str(e))
 
     def _checkout(self, local_dir):
         if 'version' in self.config:

--- a/fusesoc/provider/git.py
+++ b/fusesoc/provider/git.py
@@ -40,5 +40,3 @@ class Git(Provider):
         if version:
             args = ['-C', local_dir, 'checkout', '-q', version]
             Launcher('git', args).run()
-
-PROVIDER_CLASS = Git

--- a/fusesoc/provider/github.py
+++ b/fusesoc/provider/github.py
@@ -15,7 +15,7 @@ else:
 
 URL = 'https://github.com/{user}/{repo}/archive/{version}.tar.gz'
 
-class GitHub(Provider):
+class Github(Provider):
 
     def _checkout(self, local_dir):
         user   = self.config.get('user')
@@ -44,5 +44,3 @@ class GitHub(Provider):
         t.extractall(cache_root)
         os.rename(os.path.join(cache_root, tmp),
                   os.path.join(cache_root, core))
-
-PROVIDER_CLASS = GitHub

--- a/fusesoc/provider/local.py
+++ b/fusesoc/provider/local.py
@@ -17,5 +17,3 @@ class Local(Provider):
     @staticmethod
     def update_library(library):
         pass
-
-PROVIDER_CLASS = Local

--- a/fusesoc/provider/local.py
+++ b/fusesoc/provider/local.py
@@ -1,0 +1,21 @@
+import logging
+import os.path
+from fusesoc.provider.provider import Provider
+
+logger = logging.getLogger(__name__)
+
+class Local(Provider):
+    @staticmethod
+    def init_library(library):
+        if not os.path.isdir(library['location']):
+            logger.error("Local library at location '{}' not found.".format(library['location']))
+            exit(1)
+
+    def _checkout(self, local_dir):
+        pass
+
+    @staticmethod
+    def update_library(library):
+        pass
+
+PROVIDER_CLASS = Local

--- a/fusesoc/provider/logicore.py
+++ b/fusesoc/provider/logicore.py
@@ -32,5 +32,3 @@ class Logicore(Provider):
         args = ['-mode', 'batch',
                 '-source', script_file]
         Launcher('vivado', args, cwd=local_dir).run()
-
-PROVIDER_CLASS = Logicore

--- a/fusesoc/provider/opencores.py
+++ b/fusesoc/provider/opencores.py
@@ -28,5 +28,3 @@ class Opencores(Provider):
                          '--password', 'orpsoc',
                          repo_path,
                          local_dir]).run()
-
-PROVIDER_CLASS = Opencores

--- a/fusesoc/provider/url.py
+++ b/fusesoc/provider/url.py
@@ -18,7 +18,7 @@ else:
 
 from fusesoc.provider.provider import Provider
 
-class ProviderURL(Provider):
+class Url(Provider):
 
     def _checkout(self, local_dir):
         url = self.config.get('url')
@@ -52,5 +52,3 @@ class ProviderURL(Provider):
             shutil.copy2(filename, self.path)
         else:
             raise RuntimeError("Unknown file type '" + filetype + "' in [provider] section")
-
-PROVIDER_CLASS = ProviderURL

--- a/fusesoc/utils.py
+++ b/fusesoc/utils.py
@@ -1,6 +1,7 @@
 import subprocess
 import logging
 import sys
+import importlib
 
 if sys.version[0] == '2':
     FileNotFoundError = OSError
@@ -177,3 +178,8 @@ def setup_logging(level, monchrome=False):
         logger.addHandler(ch)
         logger.setLevel(logging.WARNING)
     logger.debug('Setup logging at level {}.'.format(level))
+
+def _import(name, package):
+    module = importlib.import_module('fusesoc.{}.{}'.format(package, name))
+    return getattr(module, name.capitalize())
+

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -57,7 +57,7 @@ def get_backend(core, flags, export):
     import os.path
     import tempfile
     import yaml
-    from fusesoc.main import _import
+    from fusesoc.utils import _import
 
     if export:
         export_root = os.path.join(build_root, core.name.sanitized_name, 'src')
@@ -72,7 +72,7 @@ def get_backend(core, flags, export):
     with open(eda_api_file,'w') as f:
         f.write(yaml.dump(eda_api))
 
-    return _import(flags['tool'])(eda_api_file=eda_api_file, work_root=work_root)
+    return _import(flags['tool'], 'edatools')(eda_api_file=eda_api_file, work_root=work_root)
 
 cmdlineargs = ' --cmdlinearg_bool --cmdlinearg_int=42 --cmdlinearg_str=hello'.split()
 plusargs    = ' --plusarg_bool --plusarg_int=42 --plusarg_str=hello'.split()

--- a/tests/test_eda_api.py
+++ b/tests/test_eda_api.py
@@ -2,17 +2,17 @@ import pytest
 
 def test_empty_eda_api():
     import tempfile
-    from fusesoc.main import _import
+    from fusesoc.utils import _import
 
     (h, eda_api_file) = tempfile.mkstemp()
 
     with pytest.raises(RuntimeError):
-        backend = _import('icarus')(eda_api_file=eda_api_file)
+        backend = _import('icarus', 'edatools')(eda_api_file=eda_api_file)
 
 def test_incomplete_eda_api():
     import tempfile
     import yaml
-    from fusesoc.main import _import
+    from fusesoc.utils import _import
 
     (h, eda_api_file) = tempfile.mkstemp()
     contents = []
@@ -21,14 +21,14 @@ def test_incomplete_eda_api():
         f.write(yaml.dump({'version' : '0.1.1'}))
 
     with pytest.raises(RuntimeError) as excinfo:
-        backend = _import('icarus')(eda_api_file=eda_api_file)
+        backend = _import('icarus', 'edatools')(eda_api_file=eda_api_file)
     assert "Missing required parameter 'name'" in str(excinfo.value)
 
     with open(eda_api_file,'w') as f:
         f.write(yaml.dump({'version' : '0.1.1',
                            'name' : 'corename'}))
 
-    backend = _import('icarus')(eda_api_file=eda_api_file)
+    backend = _import('icarus', 'edatools')(eda_api_file=eda_api_file)
 
 
 def test_eda_api_vpi():

--- a/tests/test_libraries.py
+++ b/tests/test_libraries.py
@@ -20,6 +20,7 @@ library_root = {library_root}
 location = {cores_root}
 auto-sync = {auto_sync}
 sync-uri = {sync_uri}
+sync-type = {sync_type}
 """
 
 sync_uri = 'https://github.com/fusesoc/fusesoc-cores'
@@ -34,7 +35,8 @@ def test_library_location():
             cores_root = cores_root,
             library_root = library_root,
             auto_sync = 'false',
-            sync_uri = sync_uri
+            sync_uri = sync_uri,
+            sync_type = 'git'
             )
         )
     tcf.seek(0)
@@ -45,19 +47,24 @@ def test_library_location():
     _get_core(cm, 'mor1kx-generic')
     _get_core(cm, 'atlys')
 
-def test_library_add():
+def test_library_add(caplog):
     from fusesoc.main import add_library
     from fusesoc.coremanager import CoreManager
 
+    # Set up safe environment variables for library location
+    os.environ['XDG_DATA_HOME']  =  library_root
+
     tcf = tempfile.NamedTemporaryFile(mode="w+")
+    clone_target = "tests/test_libraries"
 
     conf = Config(file=tcf)
+    conf.library_root = library_root
     cm = CoreManager(conf)
 
     args = Namespace()
 
     args.name = 'fusesoc-cores'
-    args.location = None
+    args.location = clone_target
     args.config = tcf
     args.no_auto_sync = False
     vars(args)['sync-uri'] = sync_uri
@@ -65,12 +72,46 @@ def test_library_add():
     add_library(cm, args)
 
     expected = """[library.fusesoc-cores]
-sync-uri = https://github.com/fusesoc/fusesoc-cores"""
+sync-uri = https://github.com/fusesoc/fusesoc-cores
+location = {}""".format(os.path.abspath(clone_target))
 
     tcf.seek(0)
     result = tcf.read().strip()
 
     assert expected == result
+
+    tcf.close()
+    shutil.rmtree(clone_target)
+    tcf = tempfile.NamedTemporaryFile(mode="w+")
+
+    args.config = tcf
+    args.location = None
+    vars(args)['sync-type'] = 'git'
+
+    expected = """[library.fusesoc-cores]
+sync-uri = https://github.com/fusesoc/fusesoc-cores
+sync-type = git"""
+
+    add_library(cm, args)
+
+    tcf.seek(0)
+    result = tcf.read().strip()
+
+    assert expected == result
+
+    tcf.close()
+    shutil.rmtree(os.path.join(library_root, "fusesoc"))
+    tcf = tempfile.NamedTemporaryFile(mode="w+")
+
+    args.config = tcf
+    vars(args)['sync-type'] = 'local'
+    vars(args)['sync-uri'] = 'tests/capi2_cores'
+    args.location = None
+
+    with caplog.at_level(logging.INFO):
+        add_library(cm, args)
+
+    assert "Interpreting sync-uri 'tests/capi2_cores' as location for local provider." in caplog.text
 
 def test_library_update(caplog):
     from fusesoc.main import update, init_coremanager, init_logging
@@ -87,7 +128,8 @@ def test_library_update(caplog):
                 cores_root = clone_target,
                 library_root = library_root,
                 auto_sync = 'false',
-                sync_uri = sync_uri
+                sync_uri = sync_uri,
+                sync_type = 'git'
                 )
             )
         tcf.seek(0)
@@ -127,6 +169,29 @@ def test_library_update(caplog):
         assert "Updating 'test_lib'" in caplog.text
 
         caplog.clear()
+
+        tcf.close()
+        tcf = tempfile.TemporaryFile(mode="w+")
+        tcf.write(EXAMPLE_CONFIG.format(
+                build_root = build_root,
+                cache_root = cache_root,
+                cores_root = clone_target,
+                library_root = library_root,
+                auto_sync = 'true',
+                sync_uri = sync_uri,
+                sync_type = 'local'
+                )
+            )
+        tcf.seek(0)
+
+        conf = Config(file=tcf)
+
+        args.libraries = []
+
+        with caplog.at_level(logging.INFO):
+            update(cm, args)
+
+        assert "Updating 'test_lib'" in caplog.text
 
     finally:
         shutil.rmtree(clone_target)

--- a/tests/test_verilator.py
+++ b/tests/test_verilator.py
@@ -14,13 +14,13 @@ ref_dir   = os.path.join(tests_dir, __name__)
 def test_verilator_configure():
     import os.path
     import tempfile
-    from fusesoc.main import _import
+    from fusesoc.utils import _import
 
     for mode in ['cc', 'sc', 'lint-only']:
         work_root    = tempfile.mkdtemp()
         eda_api_file = os.path.join(ref_dir, mode, core.name.sanitized_name) + '.eda.yml'
 
-        backend = _import(tool)(eda_api_file=eda_api_file, work_root=work_root)
+        backend = _import(tool, 'edatools')(eda_api_file=eda_api_file, work_root=work_root)
 
         if mode is 'cc':
             _params = params
@@ -37,13 +37,13 @@ def test_verilator_configure():
 def test_verilator_run():
     import os.path
     import tempfile
-    from fusesoc.main import _import
+    from fusesoc.utils import _import
     ref_dir_cc = os.path.join(ref_dir, 'cc')
     dummy_exe = 'V'+core.verilator.top_module
 
     work_root    = tempfile.mkdtemp()
     eda_api_file = os.path.join(ref_dir_cc, core.name.sanitized_name)+ '.eda.yml'
-    backend = _import(tool)(eda_api_file=eda_api_file, work_root=work_root)
+    backend = _import(tool, 'edatools')(eda_api_file=eda_api_file, work_root=work_root)
     shutil.copy(os.path.join(ref_dir, dummy_exe),
                 os.path.join(work_root, dummy_exe))
 


### PR DESCRIPTION
This patch adds a 'sync-type' field to the library sections of the config file which specifies how to acquire the library. Currently two sync-types are supported, 'git' and 'local', with 'git' assuming a Git repository and 'local' acting much like `pip install -e` - that is,  simply using the contents of the provided directory directly. Down the line we would add 'hg', 'svn', or other backends as needed.

The Provider classes/modules which are used to fetch cores are expanded to allow managing libraries as well.

This patch is intended for merging sometime after 1.8.