### PR TITLE
Dockerise tests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,15 @@
+## Build fusesoc-img
 # docker build  -t fusesoc-img  .
-# docker run  --rm -it  -v $PWD:/fusesoc fusesoc-img  -c "pip install -e .;py.test"
+## Run tests in container and bolt.
+# docker run  --rm -it  -v $PWD:/fusesoc fusesoc-img
+## Run container with bash terminal for manual debugging
+# docker run  --rm -it  -v $PWD:/fusesoc fusesoc-img  -c /bin/bash
 
 FROM ubuntu:latest
 RUN apt-get update
 RUN apt-get install -y git man python python-pip  python-setuptools subversion vim wget curl
 
 WORKDIR /fusesoc
+
+CMD ["-c","pip install -e .;py.test;rm -rf tests/cache tests/__pycache__"]
 ENTRYPOINT ["/bin/bash"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+# docker build  -t fusesoc-img  .
+# docker run  --rm -it  -v $PWD:/fusesoc fusesoc-img  -c "pip install -e .;py.test"
+
+FROM ubuntu:latest
+RUN apt-get update
+RUN apt-get install -y git man python python-pip  python-setuptools subversion vim wget curl
+
+WORKDIR /fusesoc
+ENTRYPOINT ["/bin/bash"]


### PR DESCRIPTION
This is a small Dockerfile for fuseson-img. it's based on ubuntu:latest. it defaults to running tests but It can be used for development as well. small cavity: any files created in a container, they will have root permission. 

couple of scenarios where this comes handy:
- version compatibility. I had a problem with dev machine that had an old git installed. it didn't support "git apply --unsafe-paths". If there is a minimum version for a dependency package (iverilog, verilator), maybe we can build and deploy those into the container.

- for system tests. need a portable way to install edatools like modelsim, Altera and xilinx stuff. This is for installation only. licensing for commercial software would be still a problem specially if you have node-locked license.