### PR TITLE
Add bash completion script by skristiansson

### DIFF
--- a/extras/bash-completion
+++ b/extras/bash-completion
@@ -1,0 +1,25 @@
+# Copy this script to /etc/bash_completion.d/fusesoc to enjoy bash completion
+# for fusesoc.
+
+_fusesoc()
+{
+    local cur prev words cword
+    _init_completion || return
+
+    COMPREPLY=()
+
+    case $prev in
+        run|build|sim|pgm|fetch|core-info)
+            COMPREPLY=( $( compgen -W "$( $1 list-cores | awk 'NR > 5' |
+                awk '{print $1}' )" -- $cur ) )
+            ;;
+    esac
+
+    if [[ $cword -eq 1 ]]; then
+        COMPREPLY=( $( compgen -W 'build init pgm fetch list-cores core-info
+                list-paths library run sim update' -- "$cur" ) )
+    fi
+    return 0
+
+} &&
+complete -F _fusesoc fusesoc


### PR DESCRIPTION
This adds the script created by Stefan in PR #57 as a starting point for
further improvements on this really useful tool.

Automatically installing this file with pip is something between
impossible and annoying for multiple reasons.

- There's no way to select between Windows and Linux, with and without
  bash, etc.
- The file could be installed into /etc/bash_completion.d by setuptools,
  but not by wheels. (Not a big problem right now, since fusesoc doesn't
  contain binary components.)
  Reference: https://github.com/pypa/wheel/issues/92
- Installing the file next to the package is tricky, however could be
  done using data_files & friends in setup.py. However that is rather
  tricky and provides no clear benefit over getting the file as needed
  with curl.

So I'd go with just placing this file in the source tree and documenting
its use with
$ sudo curl https://raw.githubusercontent.com/olofk/fusesoc/master/extras/bash-completion -o /etc/bash_completion.d
or (without root privileges)
$ curl https://raw.githubusercontent.com/olofk/fusesoc/master/extras/bash-completion >> ~/.bash_completion