### PR TITLE
Library bugfix and --global flag

### DIFF
--- a/fusesoc/config.py
+++ b/fusesoc/config.py
@@ -31,6 +31,10 @@ class Config(object):
                         os.path.join(xdg_config_home, 'fusesoc','fusesoc.conf'),
                         'fusesoc.conf']
             else:
+                logger.debug("Using config file '{}'".format(path))
+                if not os.path.isfile(path):
+                    with open(path, 'a'):
+                        pass
                 config_files = [path]
 
             logger.debug('Looking for config files from ' + ':'.join(config_files))

--- a/fusesoc/main.py
+++ b/fusesoc/main.py
@@ -154,6 +154,9 @@ def add_library(cm, args):
     if 'sync-type' in vars(args):
         provider = vars(args)['sync-type']
         library['sync-type'] = provider
+    elif os.path.isdir(sync_uri):
+        provider = 'local'
+        library['sync-type'] = provider
     else:
         provider = 'git'
 

--- a/fusesoc/main.py
+++ b/fusesoc/main.py
@@ -176,8 +176,13 @@ def add_library(cm, args):
 
     if args.config:
         config = Config(file=args.config)
+    elif vars(args)['global']:
+        xdg_config_home = os.environ.get('XDG_CONFIG_HOME') or \
+                          os.path.join(os.path.expanduser('~'), '.config')
+        config_file = os.path.join(xdg_config_home, 'fusesoc', 'fusesoc.conf')
+        config = Config(path=config_file)
     else:
-        config = Config()
+        config = Config(path="fusesoc.conf")
 
     try:
         config.add_library(name, library)
@@ -467,6 +472,7 @@ def parse_args():
     parser_library_add.add_argument('--location', help='The location to store the library into (defaults to $XDG_DATA_HOME/[name])')
     parser_library_add.add_argument('--sync-type', help="The provider type for the library. Defaults to 'git'.", choices=['git', 'local'])
     parser_library_add.add_argument('--no-auto-sync', action='store_true', help='Disable automatic updates of the library')
+    parser_library_add.add_argument('--global', action='store_true', help='Use the global FuseSoc config file in $XDG_CONFIG_HOME/fusesoc/fusesoc.conf')
     parser_library_add.set_defaults(func=add_library)
 
     # run subparser


### PR DESCRIPTION
Fixes local library detection bug and implements --global flag to indicate which fusesoc.conf should be used.

A possible enhancement might be to move the --global flag up to the `library` subparser or even the main `fusesoc` parser rather than leaving it at the `library add` level.