### PR TITLE
Vivado: Use manual source management mode

### DIFF
--- a/fusesoc/edatools/vivado.py
+++ b/fusesoc/edatools/vivado.py
@@ -102,7 +102,8 @@ class Vivado(EdaTool):
             parameters += "set_property verilog_define \""+defines+"\" [get_filesets sources_1]\n"
 
         if self.toplevel:
-            extras += "set_property top "+self.toplevel+" [current_fileset]"
+            extras += "set_property top "+self.toplevel+" [current_fileset]\n"
+            extras += "set_property source_mgmt_mode None [current_project]\n"
 
         # Write the formatted string to the tcl file
         tcl_file.write(PROJECT_TCL_TEMPLATE.format(

--- a/tests/test_vivado/mor1kx-arty_0.tcl
+++ b/tests/test_vivado/mor1kx-arty_0.tcl
@@ -64,6 +64,8 @@ read_xdc ../../../cores/misc/xdc_file
 
 set_param project.enableVHDL2008 1
 set_property top mor1kx_arty_top [current_fileset]
+set_property source_mgmt_mode None [current_project]
+
 
 # By default create_project creates the synth_1 and impl_1 runs.
 # To explicitly create customized runs, uncomment the code below.


### PR DESCRIPTION
Since Vivado 2017.1 Xilinx has included a source code scanner into
Vivado which parses the HDL sources in order to display the hierarchy of
files in the UI. They did that by adding another parser for Verilog (at
least), which understands a different subset of Verilog than the parser
used in synthesis. As soon as non-parsable constructs are found Vivado
aborts the parsing process already before starting the "real" parser in
the Synthesis step, resulting in modules which cannot be found (even
though they are there and found during synthesis).

See https://www.xilinx.com/support/answers/69846.html for the Xilinx
take on this wonderful new feature.

We simply disable this new mode, since it doesn't bring anything except
increased build times and (sometimes) broken builds.