### PR TITLE
Vivado: simplify programming TCL script

### DIFF
--- a/fusesoc/templates/vivado/vivado-program.tcl.j2
+++ b/fusesoc/templates/vivado/vivado-program.tcl.j2
@@ -2,27 +2,7 @@
 
 open_hw
 connect_hw_server
-
-set board ""
-
-foreach {{ target }} [get_hw_targets] {{ '{{' }}
-    puts "$target"
-    current_hw_target $target
-    open_hw_target
-    if {{ '{{' }} [get_hw_devices] == "{{ hw_device }}" }} {{ '{{' }}
-        set board [current_hw_target]
-        break
-    }}
-    close_hw_target
-}}
-
-{% raw %}
-if {{ $board == "" }} {{
-    puts "Did not find board"
-    exit 1
-}}
-{% endraw %}
-
-current_hw_device {{ hw_device }}
-set_property PROGRAM.FILE "{{ bitstream }}" [current_hw_device]
-program_hw_devices [current_hw_device]
+open_hw_target
+current_hw_device [get_hw_devices {{ hw_device }}]
+set_property PROGRAM.FILE { {{ bitstream_name }} } [get_hw_devices {{ hw_device }}]
+program_hw_devices [get_hw_devices {{ hw_device }}]


### PR DESCRIPTION
The previously used template was unnecessarily complex. We anyhow only
support the standard case of a single board being connected to the local
machine, and in this case, the default set of TCL commands works just
fine (and also gives an appropriate error if the board is not found, for
example).