### PR TITLE
Add Spyglass backend

### DIFF
--- a/edalize/edatool.py
+++ b/edalize/edatool.py
@@ -224,6 +224,18 @@ class Edatool(object):
             getattr(self, paramtype)[key] = _value
         self.parsed_args = True
 
+    def render_template(self, template_file, target_file, template_vars = {}):
+        """
+        Render a Jinja2 template for the backend
+
+        The template file is expected in the directory templates/BACKEND_NAME.
+        """
+        template_dir = str(self.__class__.__name__).lower()
+        template = self.jinja_env.get_template(os.path.join(template_dir, template_file))
+        file_path = os.path.join(self.work_root, target_file)
+        with open(file_path, 'w') as f:
+            f.write(template.render(template_vars))
+
     def _get_fileset_files(self, force_slash=False):
         class File:
             def __init__(self, name, file_type, logical_name):

--- a/edalize/spyglass.py
+++ b/edalize/spyglass.py
@@ -1,0 +1,129 @@
+import logging
+import os.path
+import platform
+import re
+
+from edalize.edatool import Edatool
+
+logger = logging.getLogger(__name__)
+
+""" Synopsys (formerly Atrenta) Spyglass Backend
+
+Spyglass performs static source code analysis on HDL code and checks for common
+coding errors or coding style violations.
+
+Example snippet of a CAPI2 description file:
+
+spyglass:
+  methodology: "GuideWare/latest/block/rtl_handoff"
+  goals:
+    - lint/lint_rtl
+  spyglass_options:
+    # prevent error SYNTH_5273 on generic RAM descriptions
+    - handlememory yes
+
+"""
+class Spyglass(Edatool):
+
+    tool_options = {
+        'members' : {
+            'methodology' : 'String'
+        },
+        'lists': {
+            'goals': 'String',
+            'spyglass_options': 'String',
+        },
+    }
+
+    argtypes = ['vlogdefine', 'vlogparam']
+
+    tool_options_defaults = {
+         'methodology': 'GuideWare/latest/block/rtl_handoff',
+         'goals': [ 'lint/lint_rtl' ],
+         'spyglass_options': [],
+    }
+
+    def _set_tool_options_defaults(self):
+        for key, default_value in self.tool_options_defaults.items():
+            if not key in self.tool_options:
+                logger.info("Set Spyglass tool option %s to default value %s" 
+                    % (key, str(default_value)))
+                self.tool_options[key] = default_value
+
+
+    """ Configuration is the first phase of the build
+
+    This writes the project TCL files and Makefile. It first collects all
+    sources, IPs and contraints and then writes them to the TCL file along
+    with the build steps.
+    """
+    def configure_main(self):
+        self._set_tool_options_defaults()
+
+        (src_files, incdirs) = self._get_fileset_files(force_slash=True)
+
+        self.jinja_env.filters['src_file_filter'] = self.src_file_filter
+
+        has_systemVerilog = False
+        for src_file in src_files:
+            if src_file.file_type.startswith('systemVerilogSource'):
+                has_systemVerilog = True
+                break
+
+        template_vars = {
+            'name'              : self.name,
+            'src_files'         : src_files,
+            'incdirs'           : incdirs,
+            'tool_options'      : self.tool_options,
+            'toplevel'          : self.toplevel,
+            'vlogparam'         : self.vlogparam,
+            'vlogdefine'        : self.vlogdefine,
+            'has_systemVerilog' : has_systemVerilog,
+            'sanitized_goals'   : [],
+        }
+
+        self.render_template('spyglass-project.prj.j2',
+                             self.name + '.prj',
+                             template_vars)
+
+        # Create a single TCL file for each goal
+        goals = ['Design_Read'] + self.tool_options['goals']
+
+        for goal in goals:
+            template_vars['goal'] = goal
+            sanitized_goal = re.sub(r"[^a-zA-Z0-9]", '_', goal).lower()
+            template_vars['sanitized_goals'].append(sanitized_goal)
+
+            self.render_template('spyglass-run-goal.tcl.j2',
+                                 'spyglass-run-%s.tcl' % sanitized_goal,
+                                 template_vars)
+
+
+        self.render_template('Makefile.j2',
+                             'Makefile',
+                             template_vars)
+
+    def src_file_filter(self, f):
+        def _vhdl_source(f):
+            s = 'read_file -type vhdl'
+            if f.logical_name:
+                s += ' -library '+f.logical_name
+            return s
+
+        file_types = {
+            'verilogSource'       : 'read_file -type verilog',
+            'systemVerilogSource' : 'read_file -type verilog',
+            'vhdlSource'          : _vhdl_source(f),
+            'tclSource'           : 'source',
+            'waiver'              : 'read_file -type waiver',
+        }
+        _file_type = f.file_type.split('-')[0]
+        if _file_type in file_types:
+            return file_types[_file_type] + ' ' + f.name
+        elif _file_type == 'user':
+            return ''
+        else:
+            _s = "{} has unknown file type '{}'"
+            logger.warning(_s.format(f.name,
+                                     f.file_type))
+        return ''

--- a/edalize/templates/spyglass/Makefile.j2
+++ b/edalize/templates/spyglass/Makefile.j2
@@ -1,0 +1,12 @@
+NAME := {{ name }}
+
+run-goals: {% for goal in sanitized_goals %}run-goal-{{ goal }} {% endfor %}
+
+{% for goal in sanitized_goals %}
+run-goal-{{ goal }}:
+	sg_shell -enable_pass_exit_codes -tcl spyglass-run-{{ goal }}.tcl
+
+{% endfor -%}
+
+run-gui:
+	spyglass -project $(NAME).prj

--- a/edalize/templates/spyglass/spyglass-project.prj.j2
+++ b/edalize/templates/spyglass/spyglass-project.prj.j2
@@ -1,0 +1,51 @@
+#!SPYGLASS_PROJECT_FILE
+#!VERSION 3.0
+#  -------------------------------------------------------------------
+#  This is a automatically generated project file by fusesoc.
+#  -------------------------------------------------------------------
+
+
+set_option projectwdir .
+set_option language_mode mixed
+set_option designread_enable_synthesis yes
+set_option designread_disable_flatten no
+
+# Make no only FATAL messages return a non-zero exit code, but also ERRORs and
+# WARNINGs
+set_option enable_pass_exit_codes yes
+
+{% for option in tool_options.spyglass_options %}
+set_option {{ option }}
+{% endfor %}
+
+{% for src_file in src_files if src_file|src_file_filter%}
+{{ src_file|src_file_filter }}
+{% endfor %}
+
+{% if vlogparam -%}
+set_option param {
+  {%- for k, v in vlogparam.items() %}{{ k }}={{ v|param_value_str }} {% endfor -%}
+  }
+{%- endif %}
+
+{% if vlogdefine -%}
+set_option define {
+  {%- for k, v in vlogdefine.items() %}{{ k }}={{ v|param_value_str }} {% endfor -%}
+  }
+{%- endif %}
+
+{% if incdirs -%}
+set_option incdir [list {{ incdirs|join(' ') }}]
+{%- endif %}
+
+{% if toplevel -%}
+set_option top {{ toplevel }}
+{%- endif %}
+
+{% if has_systemVerilog -%}
+set_option enableSV09 yes
+{%- endif %}
+
+set_option active_methodology $SPYGLASS_HOME/{{ tool_options.methodology }}
+
+current_methodology $SPYGLASS_HOME/{{ tool_options.methodology }}

--- a/edalize/templates/spyglass/spyglass-run-goal.tcl.j2
+++ b/edalize/templates/spyglass/spyglass-run-goal.tcl.j2
@@ -1,0 +1,16 @@
+open_project {{ name }}.prj
+
+current_goal {{ goal }}
+
+set rc [run_goal]
+close_project -force
+
+set errorCode [lindex $rc 0]
+set errorMsg [lindex $rc 1]
+if { $errorCode } {
+  puts stderr "SpyGlass run failed: $errorMsg ($errorCode)"
+}
+
+# requires sg_shell to be called with -enable_pass_exit_codes, otherwise
+# all non-fatal exit codes are mapped to 0
+exit $errorCode

--- a/edalize/vivado.py
+++ b/edalize/vivado.py
@@ -69,12 +69,6 @@ class Vivado(Edatool):
         self.render_template('vivado-run.tcl.j2',
                              self.name+"_run.tcl")
 
-    def render_template(self, template_file, target_file, template_vars = {}):
-        template = self.jinja_env.get_template(os.path.join('vivado', template_file))
-        file_path = os.path.join(self.work_root, target_file)
-        with open(file_path, 'w') as f:
-            f.write(template.render(template_vars))
-
     def src_file_filter(self, f):
         def _vhdl_source(f):
             s = 'read_vhdl'

--- a/fusesoc/capi1/core.py
+++ b/fusesoc/capi1/core.py
@@ -338,7 +338,7 @@ class Core:
         if 'tool' in flags:
             if flags['tool'] in ['ghdl', 'icarus', 'isim', 'modelsim', 'rivierapro', 'xsim']:
                 flow = 'sim'
-            elif flags['tool'] in ['icestorm', 'ise', 'quartus', 'verilator', 'vivado']:
+            elif flags['tool'] in ['icestorm', 'ise', 'quartus', 'verilator', 'vivado', 'spyglass']:
                 flow = 'synth'
         elif 'target' in flags:
             if flags['target'] is 'synth':


### PR DESCRIPTION
This PR adds a Synopsys (formerly Atrenta) Spyglass backend to fusesoc. The general approach has been discussed in #158. As discussed there the backend is CAPI2-only.

Example use
~~~
git clone git@github.com:optimsoc/optimsoc.git
cd optimsoc
git checkout spyglass
export OPTIMSOC_SRC=$PWD

fusesoc --verbose --cores-root $OPTIMSOC_SRC run --target=synth --tool=spyglass optimsoc:examples:compute_tile_nexys4ddr_capi2
~~~

While working on this I've noticed a couple things I don't yet understand of CAPI2 or might also be limitations. I've made note of these things in https://github.com/optimsoc/optimsoc/blob/spyglass/examples/fpga/nexys4ddr/compute_tile/compute_tile_nexys4ddr_capi2.core. In this case, all dependent cores are described in CAPI1 files, only the top-level core file is written in CAPI2. 

1. I cannot use a new (and self-defined) "lint" target to run spyglass, but I must use the synth target, otherwise no RTL files of our dependencies (as defined in CAPI1 files) are found.
2. I had to "hack" into the CAPI1 parser to actually add the files to the synth backend if Spyglass is used. 

I'm not sure how much of this logic is intended, what is a bug and what is just a limitation. Maybe @olofk you can give some insight here?