### PR TITLE
Run tests with tox

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,12 +4,8 @@ python:
   - "2.7"
   - "3.4"
   - "3.5"
+  - "3.6"
 install:
-  - "pip install ."
-env:
-  - MODEL_TECH=dummy_value
+  - pip install tox-travis
 script:
-  - "fusesoc init -y"
-  - "fusesoc list-cores"
-  - "fusesoc update"
-  - "py.test"
+  - tox

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,15 @@
+[tox]
+envlist = py2,py3
+
+[testenv]
+deps = pytest
+commands = /bin/rm -rf {homedir}/.local/share/fusesoc
+           fusesoc init -y
+           fusesoc list-cores
+           fusesoc update
+           pytest
+
+setenv = MODEL_TECH = dummy_value
+
+
+whitelist_externals = rm


### PR DESCRIPTION
Using tox adds benefits over simply using "pip install ." in that it
- makes it easier for developers to run test on multiple Python versions
  (especially Python 2 and Python 3)
- and catches bugs which related to packaging (e.g. failing to add
  templates files to the distribution).

Fixes #213