### PR TITLE
Add quartus library support

### DIFF
--- a/edalize/quartus.py
+++ b/edalize/quartus.py
@@ -135,10 +135,17 @@ set_global_assignment -name TOP_LEVEL_ENTITY {}
                     _s = "{} has unknown file type '{}'"
                     logger.warning(_s.format(f.name,
                                              f.file_type))
+ 
                 if _type:
-                    _s = "set_global_assignment -name {} {}\n"
-                    tcl_file.write(_s.format(_type,
-                                             f.name.replace('\\', '/')))
+                    if f.logical_name != "":            
+                        _s = "set_global_assignment -name {} -library {} {}\n"
+                        tcl_file.write(_s.format(_type,
+                                                 f.logical_name,
+                                                 f.name.replace('\\', '/')))
+                    else:
+                        _s = "set_global_assignment -name {} {}\n"
+                        tcl_file.write(_s.format(_type,
+                                                 f.name.replace('\\', '/')))                         
 
             for include_dir in incdirs:
                 tcl_file.write("set_global_assignment -name SEARCH_PATH " + include_dir.replace('\\', '/') + '\n')

--- a/tests/edalize/test_quartus/test_quartus_0.tcl
+++ b/tests/edalize/test_quartus/test_quartus_0.tcl
@@ -16,6 +16,6 @@ source tcl_file.tcl
 set_global_assignment -name VERILOG_FILE vlog_file.v
 set_global_assignment -name VERILOG_FILE vlog05_file.v
 set_global_assignment -name VHDL_FILE vhdl_file.vhd
-set_global_assignment -name VHDL_FILE vhdl_lfile
+set_global_assignment -name VHDL_FILE -library libx vhdl_lfile
 set_global_assignment -name VHDL_FILE vhdl2008_file
 set_global_assignment -name SEARCH_PATH .


### PR DESCRIPTION
This updates the test_quartus test and backend implementation to allow Quartus to compile files into libraries based on FuseSoC's logical_name concept. Fixes #217 