### PR TITLE
Allow < character in Word parsing.

### DIFF
--- a/fusesoc/capi2/core.py
+++ b/fusesoc/capi2/core.py
@@ -48,7 +48,7 @@ class String(str):
                 return t.expr
             else:
                 return []
-        word = Word(alphanums+':>.[]_-,=~/')
+        word = Word(alphanums+':<>.[]_-,=~/')
         conditional = Forward()
         conditional << (Optional("!")("negate") + word("cond") + Suppress('?') + Suppress('(') + OneOrMore(conditional ^ word)("expr") + Suppress(')')).setParseAction(cb_conditional)
         #string = (function ^ word)


### PR DESCRIPTION
I was experimenting with how the dependency system worked and noticed that if I specified a dependency in a CAPI2 file of the form:

filesets:
  rtl:
    files:
      - some/path/to/file.vhd
    depend:
      - "<vendor:library:name:1.0.0"

I get an error:

pyparing.ParseException: Expected {Forward: ... ^ W:(ABCD...)} (at char 0), (line:1, col:1)

This patch allows the '<' character to appear here, which allows dependencies to include restrictions on less than a specific version. 