### PR TITLE
Spyglass: Fix parameter passing

### DIFF
--- a/edalize/spyglass.py
+++ b/edalize/spyglass.py
@@ -1,5 +1,6 @@
 import logging
 import re
+from collections import OrderedDict
 
 from edalize.edatool import Edatool
 
@@ -49,7 +50,7 @@ class Spyglass(Edatool):
     def _set_tool_options_defaults(self):
         for key, default_value in self.tool_options_defaults.items():
             if not key in self.tool_options:
-                logger.info("Set Spyglass tool option %s to default value %s" 
+                logger.info("Set Spyglass tool option %s to default value %s"
                     % (key, str(default_value)))
                 self.tool_options[key] = default_value
 
@@ -73,13 +74,18 @@ class Spyglass(Edatool):
                 has_systemVerilog = True
                 break
 
+        # Spyglass expects all parameters in the form module.parameter
+        # Always prepend the toplevel module name to be consistent with all other
+        # backends, which do not require this syntax.
+        vlogparam_spyglass = OrderedDict((self.toplevel + "." + p, v) for (p, v) in self.vlogparam.items())
+
         template_vars = {
             'name'              : self.name,
             'src_files'         : src_files,
             'incdirs'           : incdirs,
             'tool_options'      : self.tool_options,
             'toplevel'          : self.toplevel,
-            'vlogparam'         : self.vlogparam,
+            'vlogparam'         : vlogparam_spyglass,
             'vlogdefine'        : self.vlogdefine,
             'has_systemVerilog' : has_systemVerilog,
             'sanitized_goals'   : [],

--- a/tests/edalize/test_spyglass/defaults/test_spyglass_0.prj
+++ b/tests/edalize/test_spyglass/defaults/test_spyglass_0.prj
@@ -23,7 +23,7 @@ read_file -type vhdl vhdl_file.vhd
 read_file -type vhdl -library libx vhdl_lfile
 read_file -type vhdl vhdl2008_file
 
-set_option param {vlogparam_bool=1 vlogparam_int=42 vlogparam_str=hello }
+set_option param {top_module.vlogparam_bool=1 top_module.vlogparam_int=42 top_module.vlogparam_str=hello }
 set_option define {vlogdefine_bool=1 vlogdefine_int=42 vlogdefine_str=hello }
 set_option incdir [list .]
 set_option top top_module

--- a/tests/edalize/test_spyglass/tooloptions/test_spyglass_0.prj
+++ b/tests/edalize/test_spyglass/tooloptions/test_spyglass_0.prj
@@ -24,7 +24,7 @@ read_file -type vhdl vhdl_file.vhd
 read_file -type vhdl -library libx vhdl_lfile
 read_file -type vhdl vhdl2008_file
 
-set_option param {vlogparam_bool=1 vlogparam_int=42 vlogparam_str=hello }
+set_option param {top_module.vlogparam_bool=1 top_module.vlogparam_int=42 top_module.vlogparam_str=hello }
 set_option define {vlogdefine_bool=1 vlogdefine_int=42 vlogdefine_str=hello }
 set_option incdir [list .]
 set_option top top_module


### PR DESCRIPTION
Spyglass requires parameter to always be in a dotted (hierarchical)
syntax, which is different from most other tools (e.g. Vivado). To have
a consistent interface prefix the parameter name with the toplevel
module name before passing to Spyglass.