### PR TITLE
Changes needed for a CAPI 1 compatible VCS backend

### DIFF
--- a/doc/capi1.adoc
+++ b/doc/capi1.adoc
@@ -56,7 +56,7 @@ Each element in the list is subjected to expansion of environment variables and
 [[SimulatorList]]
 SimulatorList
 ~~~~~~~~~~~~~
-List of supported simulators. Allowed values are ghdl, icarus, isim, modelsim, verilator, xsim
+List of supported simulators. Allowed values are ghdl, icarus, isim, modelsim, vcs, verilator, xsim
 
 
 
@@ -283,6 +283,18 @@ trellis
 |nextpnr_options | <<StringList,StringList>> | nextpnr options
 |top_module | String | RTL top-level module
 |yosys_synth_options | <<StringList,StringList>> | Additional options for the synth_* commands in yosys
+|==============================
+
+
+
+vcs
+~~~
+
+[cols="2,1,5",options="header"]
+|==============================
+|Name | Type | Description
+|depend | <<VlnvList,VlnvList>> | Tool-specific Dependencies
+|vcs_options | <<StringList,StringList>> | Extra vcs compile options
 |==============================
 
 

--- a/fusesoc/capi1/core.py
+++ b/fusesoc/capi1/core.py
@@ -341,7 +341,7 @@ class Core:
     def _get_flow(self, flags):
         flow = None
         if 'tool' in flags:
-            if flags['tool'] in ['ghdl', 'icarus', 'isim', 'modelsim', 'rivierapro', 'xsim']:
+            if flags['tool'] in ['ghdl', 'icarus', 'isim', 'modelsim', 'rivierapro', 'xsim', 'vcs']:
                 flow = 'sim'
             elif flags['tool'] in ['icestorm', 'ise', 'quartus', 'verilator', 'vivado', 'spyglass', 'trellis']:
                 flow = 'synth'

--- a/fusesoc/capi1/section.py
+++ b/fusesoc/capi1/section.py
@@ -150,9 +150,9 @@ class EnumList(list):
             return _valid
 
 class SimulatorList(EnumList):
-    """List of supported simulators. Allowed values are ghdl, icarus, isim, modelsim, verilator, xsim"""
+    """List of supported simulators. Allowed values are ghdl, icarus, isim, modelsim, vcs, verilator, xsim"""
     def __new__(cls, *args, **kwargs):
-        values = ['ghdl', 'icarus', 'modelsim', 'verilator', 'isim', 'xsim']
+        values = ['ghdl', 'icarus', 'modelsim', 'verilator', 'isim', 'xsim', 'vcs']
         return super(SimulatorList, cls).__new__(cls, *args, values=values)
 
 class SourceType(str):
@@ -437,6 +437,23 @@ class XsimSection(ToolSection):
     def __str__(self):
         s = super(XsimSection, self).__str__()
         if self.xsim_options: s += "Xsim compile options : {}\n".format(' '.join(self.xsim_options))
+        return s
+
+class VcsSection(ToolSection):
+
+    TAG = 'vcs'
+
+    def __init__(self, items=None):
+        super(VcsSection, self).__init__()
+
+        self._add_member('vcs_options', StringList, "Extra vcs compile options")
+
+        if items:
+            self.load_dict(items)
+
+    def __str__(self):
+        s = super(VcsSection, self).__str__()
+        if self.vcs_options: s += "Vcs compile options : {}\n".format(' '.join(self.vcs_options))
         return s
 
 class VerilatorSection(ToolSection):


### PR DESCRIPTION
This patch is the smallest set of changes I needed to get wb_bfm to run with the VCS backend I made for edalize, since CAPI 1 cores need accompanying fusesoc changes.

Happy to test further/make changes as needed.