### PR TITLE
Allow cores to be un-cachable

### DIFF
--- a/fusesoc/provider/provider.py
+++ b/fusesoc/provider/provider.py
@@ -8,8 +8,7 @@ class Provider(object):
         self.config = config
         self.core_root = core_root
         self.files_root = files_root
-
-        self.cachable = not (config.get('cachable', '') == 'false')
+        self.cachable = not (config.get('cachable', '') == False)
         self.patches = config.get('patches', [])
 
     def clean_cache(self):

--- a/tests/capi2_cores/misc/uncachable.core
+++ b/tests/capi2_cores/misc/uncachable.core
@@ -1,0 +1,10 @@
+CAPI=2:
+name: ::uncachable:0
+
+targets:
+  default: {}
+
+provider:
+  name     : local
+  path     : /not/relevant/to/test
+  cachable : False

--- a/tests/test_provider.py
+++ b/tests/test_provider.py
@@ -91,3 +91,16 @@ def test_url_provider():
         core = Core(os.path.join(cores_root, corename+'.core'), cache_root)
         core.setup()
         assert(os.path.isfile(os.path.join(core.files_root, 'file.v')))
+
+def test_uncachable():
+    cores_root = os.path.join(tests_dir, 'capi2_cores', 'misc')
+    cache_root = tempfile.mkdtemp('uncachable_')
+    core       = Core(os.path.join(cores_root, 'uncachable.core'), cache_root)
+    assert(core.cache_status() == 'outofdate')
+
+def test_cachable():
+    cache_root = tempfile.mkdtemp('opencores_')
+    core = Core(os.path.join(cores_root, 'misc', 'opencorescore.core'), cache_root)
+    assert(core.cache_status() == 'empty')
+    core.setup()
+    assert(core.cache_status() == 'downloaded')


### PR DESCRIPTION
In the provider __init__ function, the cachable configuration option was being compared to the string 'false'. The config object returns the value as a boolean though, meaning that the value of self.cachable was always being set to False.

This patch changes the comparison to just use a boolean and provides a couple of tests to verify expected functionality.