### PR TITLE
Fix bug in generator core pos logic.

### DIFF
--- a/fusesoc/edalizer.py
+++ b/fusesoc/edalizer.py
@@ -111,7 +111,7 @@ class Edalizer(object):
                 elif core.pos == 'last':
                     last_snippets.append(snippet)
                 else:
-                    last_snippets.append(snippet)
+                    snippets.append(snippet)
             else:
                 snippets.append(snippet)
 


### PR DESCRIPTION
Currently the default is for a generator snippet to be placed at the end.  I think this is just a typo.  It would make more sense for the default to be just append it to the list of central snippets.