### PR TITLE
Avoid yaml.load deprecation warning

### DIFF
--- a/fusesoc/capi2/core.py
+++ b/fusesoc/capi2/core.py
@@ -741,7 +741,7 @@ def _generate_classes(j, base_class):
         generatedClass = type(cls, (base_class,), class_members)
         globals()[generatedClass.__name__] = generatedClass
 
-capi2_data = yaml.load(description, Loader=yaml.FullLoader)
+capi2_data = yaml.safe_load(description)
 
 for backend in get_edatools():
     backend_name = backend.__name__

--- a/fusesoc/capi2/core.py
+++ b/fusesoc/capi2/core.py
@@ -113,7 +113,7 @@ class Core:
         self.core_root = os.path.dirname(core_file)
 
         try:
-            _root = Root(yaml.load(open(core_file)))
+            _root = Root(yaml.load(open(core_file), Loader=yaml.FullLoader))
         except KeyError as e:
             raise SyntaxError("Unknown item {}".format(e))
         except (yaml.scanner.ScannerError, yaml.constructor.ConstructorError) as e:
@@ -741,7 +741,7 @@ def _generate_classes(j, base_class):
         generatedClass = type(cls, (base_class,), class_members)
         globals()[generatedClass.__name__] = generatedClass
 
-capi2_data = yaml.load(description)
+capi2_data = yaml.load(description, Loader=yaml.FullLoader)
 
 for backend in get_edatools():
     backend_name = backend.__name__


### PR DESCRIPTION
A fresh FuseSoC build gives the following warnings:
```
[...]/site-packages/ipyxact/ipyxact.py:178: YAMLLoadWarning: calling yaml.load() without Loader=... is deprecated, as the default Loader is unsafe. Please read https://msg.pyyaml.org/load for full details.
  _generate_classes(yaml.load(ipxact_yaml.description))
[...]/site-packages/fusesoc/capi2/core.py:744: YAMLLoadWarning: calling yaml.load() without Loader=... is deprecated, as the default Loader is unsafe. Please read https://msg.pyyaml.org/load for full details.
  capi2_data = yaml.load(description)
[...]/site-packages/fusesoc/capi2/core.py:116: YAMLLoadWarning: calling yaml.load() without Loader=... is deprecated, as the default Loader is unsafe. Please read https://msg.pyyaml.org/load for full details.
  _root = Root(yaml.load(open(core_file)))
```

This handles the two FuseSoC warnings by adding the requested `Loader` argument.