### PR TITLE
Fix link in README.rst to point to up-to-date documentation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -98,7 +98,7 @@ http://www.rs-online.com/designspark/electronics/eng/blog/booting-linux-on-a-de0
 There is also some FuseSoC-related articles and extended release information on my blog_
 
 .. _blog: https://olofkindgren.blogspot.com/search/label/FuseSoC
-.. _online: doc/fusesoc.adoc
+.. _online: https://fusesoc.readthedocs.io/en/latest/index.html
 .. _orpsoc-cores: https://github.com/openrisc/orpsoc-cores
 .. _fusesoc-cores: https://github.com/fusesoc/fusesoc-cores
 .. _`bug report`: https://github.com/olofk/fusesoc/issues

--- a/doc/source/fusesoc.rst
+++ b/doc/source/fusesoc.rst
@@ -116,7 +116,7 @@ add new functionality. The following steps can be used to achieve this:
 Backends
 --------
 
-FuseSoC uses the backends available from Edalize
+FuseSoC uses the backends available from edalize_.
 
 Migration guide
 ---------------
@@ -127,3 +127,4 @@ the link:migrations{outfilesuffix}[migration guide] to learn how to keep the
 
 .. _YAML: https://yaml.org
 .. _configparser: http://docs.python.org/2/library/configparser.html
+.. _edalize: https://github.com/olofk/edalize


### PR DESCRIPTION
The README.rst on the repo points to an outdated version of the docs. It would be nice if it pointed to the [readthedocs.io site](https://fusesoc.readthedocs.io/en/latest/index.html) instead. 

Also, adding a link to edalize makes it easier to figure out what that is.