### PR TITLE
Remove jsonschema dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,5 @@ setup(
         'pytest>=3.3.0',
         'pyyaml',
         'simplesat>=0.8.0',
-        'jsonschema<3.0.0',
     ],
 )


### PR DESCRIPTION
In commit 1e644e64 the `jsonschema` dependency was set to
`jsonschema<3.0.0`. It was actually a hacky workaround since fusesoc
doesn't depend on `jsonschema` but `simplesat` does.

That's problematic as docker-compose depends on `jsonschema` as well
(`jsonschema>=2.5.1` actually). It's not uncommon to have docker-compose
installed from distribution packages, and hence jsonschema is installed
from distribution packages as well. Distributions are now updating
jsonschema to 3.x versions and we have a version conflict.

So we really need to sort things out in order to be able to remove this
version constraint. The commit message in 1e644e64 said:

> Unfortunately, as of this commit date allows alpha 2 of jsonschema
> 3.0.0 to be selected which fails to package correctly in the python
> 3.5 environment.

The commit message doesn't point to any bug report on the Python 3.5
issue, but quite a bit of time has passed since. Let's see how things
evolved; if pip picks jsonschema 3.0 on Python 3.5 and that's not
installable then people need to manually fix this dependency by first
installing jsonschema -- it's not something that a fusesoc dependency
can fix.

This actually broke with today's openSUSE Tumbleweed snapshot.