### PR TITLE
Add a aresetn signal to ensure consistent simulation between tools

### DIFF
--- a/doc/tutorials/2-creating_a_core.md
+++ b/doc/tutorials/2-creating_a_core.md
@@ -39,13 +39,14 @@ module pps
   #(parameter clk_freq_hz = 50_000_000)
    (input  clk,
     input  aresetn,
-    output reg pps_o = 1'b0);
+    output reg pps_o);
 
-   reg [$clog2(clk_freq_hz)-1:0] count = 0;
+   reg [$clog2(clk_freq_hz)-1:0] count;
 
    always @(posedge clk) begin
       if (!aresetn) begin
          count <= 0;
+         pps_o <= 0;
       end
       else
       begin


### PR DESCRIPTION
The xsim simulator doesn't start clock and reset signals in the same state as icarus.

The original example, when simulated with xsim thinks that the very first beat happens after `999_980_000` timescales and not  `1_000_000_000`.

I think adding the reset logic helps define some "undefined initial starting state" which helps the simulator.

Feel free to rename the signal as you wish.