### PR TITLE
Add file-specific logical names

### DIFF
--- a/fusesoc/capi2/core.py
+++ b/fusesoc/capi2/core.py
@@ -24,6 +24,7 @@ class File(object):
                 self.file_type       = v.get('file_type', '')
                 self.is_include_file = v.get('is_include_file', False)
                 self.copyto          = v.get('copyto', '')
+                self.logical_name    = v.get('logical_name', '')
         else:
             self.name = os.path.expandvars(tree)
             self.is_include_file = False #"FIXME"


### PR DESCRIPTION
This change makes it so that individual files can be in different libraries, similar to how the "is_include_file" member works.  