### PR TITLE
Allow generator data to be supplied to the constructor

### DIFF
--- a/fusesoc/capi2/generator.py
+++ b/fusesoc/capi2/generator.py
@@ -5,16 +5,17 @@ class Generator(object):
     filesets   = {}
     parameters = {}
     targets    = {}
-    def __init__(self):
-        with open(sys.argv[1]) as f:
-            data = yaml.safe_load(f)
+    def __init__(self, data=None):
+        if data is None:
+            with open(sys.argv[1]) as f:
+                data = yaml.safe_load(f)
 
-            self.config     = data.get('parameters')
-            self.files_root = data.get('files_root')
-            self.vlnv       = data.get('vlnv')
+        self.config     = data.get('parameters')
+        self.files_root = data.get('files_root')
+        self.vlnv       = data.get('vlnv')
 
-            #Edalize decide core_file dir. generator creates file
-            self.core_file = self.vlnv.split(':')[2]+'.core'
+        #Edalize decide core_file dir. generator creates file
+        self.core_file = self.vlnv.split(':')[2]+'.core'
 
     def add_files(self, files, fileset='rtl', targets=['default'], file_type=''):
         if not fileset in self.filesets:
@@ -38,7 +39,7 @@ class Generator(object):
                 self.targets[target]['parameters'] = []
             if not parameter in self.targets[target]['parameters']:
                 self.targets[target]['parameters'].append(parameter)
-            
+
     def write(self):
         with open(self.core_file,'w') as f:
             f.write('CAPI=2:\n')


### PR DESCRIPTION
It seems useful to allow a generator to be run as a Python module directly from a script rather than having to be run as a separate process. For example, a script could drive fusesoc/edalize and try a core with several different package settings or clock constraints.

I think a script would rather supply the configuration data directly in a dictionary rather than going through YAML, so this change allows a script to supply the data to the generator's constructor. For backward compatibility the default case loads YAML from a file on the command line.

The generator inheriting from this base class would also need to support this usage. I'll follow up with a change to the template generator that seems to work.