### PR TITLE
Pass on verbosity to edalize

### DIFF
--- a/fusesoc/utils.py
+++ b/fusesoc/utils.py
@@ -96,7 +96,7 @@ def setup_logging(level, monchrome=False, log_file=None):
     formatter = ColoredFormatter("%(levelname)s: %(message)s", monchrome)
     ch.setFormatter(formatter)
     # Which packages do we want to log from.
-    packages = ('__main__', 'fusesoc',)
+    packages = ('__main__', 'fusesoc', 'edalize',)
     for package in packages:
         logger = logging.getLogger(package)
         logger.addHandler(ch)


### PR DESCRIPTION
Log verbosity preferences (e.g. passed through --verbose) are applied
only to fusesoc, not to edalize currently.

That's slightly unexpected since edalize is "invisible" to the end user
and integrated into the flow. This simple change makes the logging
settings apply to edalize as well.