### PR TITLE
CI: Use newer library command

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,5 +11,5 @@ env:
 script:
   - "fusesoc init -y"
   - "fusesoc list-cores"
-  - "fusesoc update"
+  - "fusesoc library update"
   - "py.test"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,4 +19,4 @@ build: off
 test_script:
   - "fusesoc init -y"
   - "fusesoc list-cores"
-  - "fusesoc update"
+  - "fusesoc library update"


### PR DESCRIPTION
"fusesoc update" was renamed to "fusesoc library update". Use the new
command name in CI.