### PR TITLE
CI: Show how to run pytest in appveyor

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ python:
   - "3.7"
   - "3.8"
 install:
-  - "pip install -U jsonschema"
   - "pip install ."
 env:
   - MODEL_TECH=dummy_value

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ python:
   - "3.8"
 install:
   - "pip install setuptools --upgrade"
+  - "pip install pytest"
   - "pip install ."
 env:
   - MODEL_TECH=dummy_value
@@ -14,4 +15,4 @@ script:
   - "fusesoc init -y"
   - "fusesoc list-cores"
   - "fusesoc library update"
-  - "py.test"
+  - "pytest"

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ python:
   - "3.7"
   - "3.8"
 install:
+  - "pip install setuptools --upgrade"
   - "pip install ."
 env:
   - MODEL_TECH=dummy_value

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,3 +23,6 @@ test_script:
   - "fusesoc init -y"
   - "fusesoc list-cores"
   - "fusesoc library update"
+  # Unit tests fail under Windows at the moment for various reasons.
+  # See https://github.com/olofk/fusesoc/issues/330 for details.
+  # - "pytest"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,6 +14,7 @@ environment:
 install:
     - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
     - "pip install setuptools --upgrade"
+    - "pip install pytest"
     - "python setup.py install"
 
 build: off

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,6 @@ setup(
         'edalize>=0.1.6',
         'ipyxact>=0.2.3',
         'pyparsing',
-        'pytest>=3.3.0',
         'pyyaml',
         'simplesat>=0.8.0',
     ],


### PR DESCRIPTION
The fusesoc unit tests run with pytest in Travis, but not in Appveyor
(Windows). Enable them there as well.