### PR TITLE
Add python_requires to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,4 +43,6 @@ setup(
         'pyyaml',
         'simplesat>=0.8.0',
     ],
+    # Supported Python versions: 2.7 or 3.5+
+    python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, <4',
 )


### PR DESCRIPTION
This feature enables pip to prevent the installation if Python is too
old.