### PR TITLE
Run git apply from the directory being patched

### DIFF
--- a/fusesoc/provider/provider.py
+++ b/fusesoc/provider/provider.py
@@ -48,14 +48,7 @@ class Provider(object):
                     + os.path.join(self.files_root)
                 )
                 try:
-                    Launcher(
-                        "git",
-                        [
-                            "apply",
-                            patch_file,
-                        ],
-                        self.files_root,
-                    ).run()
+                    Launcher("git", ["apply", patch_file], self.files_root).run()
                 except OSError:
                     raise RuntimeError("Failed to call 'git' for patching core")
 

--- a/fusesoc/provider/provider.py
+++ b/fusesoc/provider/provider.py
@@ -52,11 +52,9 @@ class Provider(object):
                         "git",
                         [
                             "apply",
-                            "--unsafe-paths",
-                            "--directory",
-                            self.files_root,
                             patch_file,
                         ],
+                        self.files_root,
                     ).run()
                 except OSError:
                     raise RuntimeError("Failed to call 'git' for patching core")


### PR DESCRIPTION
Git 2.3.3 introduced a check to prevent git apply from modifying files
outside the current working directory. FuseSoC's usage of --directory
requires disabling this check with --unsafe-paths in newer versions of
git.

Older versions of git, including git 1.8.3 shipped with RHEL 7, don't
perform the check or support the --unsafe-paths option. Therefore using
--directory in this manner would require a git version check and setting
the git apply options based on the result.

The simpler option is just running git apply from the directory being
patched, especially since this is already supported by the Launcher
class.