### PR TITLE
Fix for #357

### DIFF
--- a/fusesoc/capi2/core.py
+++ b/fusesoc/capi2/core.py
@@ -205,7 +205,7 @@ class Core:
         dirs = list(set(map(os.path.dirname, src_files)))
         for d in dirs:
             if not os.path.exists(os.path.join(dst_dir, d)):
-                os.makedirs(os.path.join(dst_dir, d))
+                os.makedirs(os.path.join(dst_dir, d), exist_ok=True)
 
         for f in src_files:
             if not os.path.isabs(f):


### PR DESCRIPTION
When running sims multiple times, directories may exist from previous
runs. This fix prevents `FileExistError` from being thrown when fusesoc
attempts to create directory trees which may already exist.

Signed-off-by: Srikrishna Iyer <sriyer@google.com>