### PR TITLE
More speed improvements

### DIFF
--- a/fusesoc/capi2/core.py
+++ b/fusesoc/capi2/core.py
@@ -147,7 +147,7 @@ class Core:
         self.core_root = os.path.dirname(self.core_file)
 
         try:
-            _root = Root(yaml.safe_load(open(self.core_file)))
+            _root = Root(utils.yaml_fread(self.core_file))
         except KeyError as e:
             raise SyntaxError("Unknown item {}".format(e))
         except (yaml.scanner.ScannerError, yaml.constructor.ConstructorError) as e:
@@ -855,7 +855,7 @@ def _generate_classes(j, base_class):
         globals()[generatedClass.__name__] = generatedClass
 
 
-capi2_data = yaml.safe_load(description)
+capi2_data = utils.yaml_read(description)
 
 for backend in get_edatools():
     backend_name = backend.__name__

--- a/fusesoc/capi2/generator.py
+++ b/fusesoc/capi2/generator.py
@@ -1,5 +1,6 @@
 import sys
-import yaml
+
+from fusesoc import utils
 
 
 class Generator(object):
@@ -9,8 +10,7 @@ class Generator(object):
 
     def __init__(self, data=None):
         if data is None:
-            with open(sys.argv[1]) as f:
-                data = yaml.safe_load(f)
+            data = utils.yaml_fread(sys.argv[1])
 
         self.config = data.get("parameters")
         self.files_root = data.get("files_root")
@@ -46,12 +46,10 @@ class Generator(object):
                 self.targets[target]["parameters"].append(parameter)
 
     def write(self):
-        with open(self.core_file, "w") as f:
-            f.write("CAPI=2:\n")
-            coredata = {
-                "name": self.vlnv,
-                "filesets": self.filesets,
-                "parameters": self.parameters,
-                "targets": self.targets,
-            }
-            f.write(yaml.dump(coredata))
+        coredata = {
+            "name": self.vlnv,
+            "filesets": self.filesets,
+            "parameters": self.parameters,
+            "targets": self.targets,
+        }
+        return utils.yaml_fwrite(self.core_file, coredata, "CAPI=2:\n")

--- a/fusesoc/edalizer.py
+++ b/fusesoc/edalizer.py
@@ -2,8 +2,8 @@ import argparse
 import logging
 import os
 import shutil
-import yaml
 
+from fusesoc import utils
 from fusesoc.vlnv import Vlnv
 
 logger = logging.getLogger(__name__)
@@ -264,8 +264,7 @@ class Edalizer(object):
         self._add_parsed_args(backend_class, parsed_args)
 
     def to_yaml(self, edalize_file):
-        with open(edalize_file, "w") as f:
-            f.write(yaml.dump(self.edalize))
+        return utils.yaml_fwrite(edalize_file, self.edalize)
 
 
 from fusesoc.core import Core
@@ -318,8 +317,7 @@ class Ttptttg(object):
         logger.info("Generating " + str(self.vlnv))
         if not os.path.exists(generator_cwd):
             os.makedirs(generator_cwd)
-        with open(generator_input_file, "w") as f:
-            f.write(yaml.dump(self.generator_input))
+        utils.yaml_fwrite(generator_input_file, self.generator_input)
 
         args = [
             os.path.join(os.path.abspath(self.generator.root), self.generator.command),

--- a/fusesoc/main.py
+++ b/fusesoc/main.py
@@ -447,9 +447,7 @@ def run_backend(
         if do_configure:
             edam = edalizer.edalize
         else:
-            import yaml
-
-            edam = yaml.safe_load(open(eda_api_file))
+            edam = utils.yaml_fread(eda_api_file)
         backend = get_edatool(tool)(edam=edam, work_root=work_root)
 
     except ImportError:

--- a/fusesoc/utils.py
+++ b/fusesoc/utils.py
@@ -3,6 +3,13 @@ import logging
 import sys
 import importlib
 
+import yaml
+
+try:
+    from yaml import CSafeLoader as YamlLoader, CSafeDumper as YamlDumper
+except ImportError:
+    from yaml import SafeLoader as YamlLoader, SafeDumper as YamlDumper
+
 if sys.version[0] == "2":
     FileNotFoundError = OSError
 
@@ -117,3 +124,18 @@ def setup_logging(level, monchrome=False, log_file=None):
         logger.addHandler(ch)
         logger.setLevel(logging.WARNING)
     logger.debug("Setup logging at level {}.".format(level))
+
+
+def yaml_fwrite(filepath, content, preamble=""):
+    with open(filepath, "w") as f:
+        f.write(preamble)
+        f.write(yaml.dump(content, Dumper=YamlDumper))
+
+
+def yaml_fread(filepath):
+    with open(filepath, "r") as f:
+        return yaml.load(f, Loader=YamlLoader)
+
+
+def yaml_read(data):
+    return yaml.load(data, Loader=YamlLoader)

--- a/fusesoc/vlnv.py
+++ b/fusesoc/vlnv.py
@@ -101,6 +101,12 @@ class Vlnv(object):
             self.vendor, self.library, self.name, self.version, revision
         )
 
+    def __hash__(self):
+        return hash(str(self))
+
+    def __eq__(self, other):
+        return self.__class__ == other.__class__ and str(self) == str(other)
+
     def depstr(self):
         if self.relation == "==":
             relation = ""


### PR DESCRIPTION
In preparation for some generator work, here are two more speed improvements for fusesoc.

* Use a faster YAML parser if possible. This should be quite visible in projects with a significant amount of CAPI2 core files, and a large EDAM file.
* Cache the solved dependency tree. This won't be visible at this point, since the solving only takes place once. But as part of my work on generators, the solving will need to happen more than once, and caching helps significantly in this case.

Again, see the individual commit messages for details.