### PR TITLE
Remove support for Python 2.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,6 @@ matrix:
       python: 3.8
       env:
         - TEST_CMD="pre-commit run --all-files --show-diff-on-failure"
-    - name: "2.7"
-      python: 2.7
     - name: "3.5"
       python: 3.5
     - name: "3.6"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,11 +1,9 @@
 environment:
   matrix:
-    - PYTHON: "C:\\Python27"
     - PYTHON: "C:\\Python35"
     - PYTHON: "C:\\Python36"
     - PYTHON: "C:\\Python37"
     - PYTHON: "C:\\Python38"
-    - PYTHON: "C:\\Python27-x64"
     - PYTHON: "C:\\Python35-x64"
     - PYTHON: "C:\\Python36-x64"
     - PYTHON: "C:\\Python37-x64"

--- a/doc/source/user/installation.rst
+++ b/doc/source/user/installation.rst
@@ -10,7 +10,7 @@ Before installing FuseSoC check your system requirements.
 
 - Operating System: Linux, Windows, macOS
 - Python 3.5 or newer.
-  (Currently Python 2.7 is still supported, but not recommended. This guide assumes the use of Python 3.)
+  (The last version supporting Python 2.7 is 1.10.)
 - The Python packages ``setuptools`` and ``pip`` need to be installed for Python 3.
 
 Installing FuseSoC under Linux

--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,6 @@ setup(
         "pyyaml",
         "simplesat>=0.8.0",
     ],
-    # Supported Python versions: 2.7 or 3.5+
-    python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, <4",
+    # Supported Python versions: 3.5+
+    python_requires=">=3.5, <4",
 )


### PR DESCRIPTION
Python 2.7 reached EOL in the beginning of this year after being
supported for roughly 10 years. It's now time also for fusesoc to
benefit from the language and ecosystem improvements that happened since
then, and drop backwards-compat with Python 2.7. The last version to
support Python 2.7 is fusesoc 1.10, which can still be installed through
pip.

Fixes #337