### PR TITLE
Cleanups to CoreManager

### DIFF
--- a/fusesoc/capi1/core.py
+++ b/fusesoc/capi1/core.py
@@ -50,6 +50,10 @@ class Core:
     def __init__(self, core_file, cache_root=""):
         basename = os.path.basename(core_file)
         self.core_file = core_file
+
+        # Populated by CoreDB._solve(). TODO: Find a better solution for that.
+        self.direct_deps = []
+
         self.depend = []
         self.simulators = []
 

--- a/fusesoc/capi2/core.py
+++ b/fusesoc/capi2/core.py
@@ -146,6 +146,9 @@ class Core:
 
         self.core_root = os.path.dirname(self.core_file)
 
+        # Populated by CoreDB._solve(). TODO: Find a better solution for that.
+        self.direct_deps = []
+
         try:
             _root = Root(utils.yaml_fread(self.core_file))
         except KeyError as e:

--- a/fusesoc/coremanager.py
+++ b/fusesoc/coremanager.py
@@ -187,7 +187,7 @@ class CoreManager:
         self.db = CoreDB()
         self._lm = LibraryManager(config.library_root)
 
-    def load_cores(self, library):
+    def _load_cores(self, library):
         path = os.path.expanduser(library.location)
         if os.path.isdir(path) == False:
             raise OSError(path + " is not a directory")
@@ -217,7 +217,7 @@ class CoreManager:
             logger.warning(_s.format(library.name, abspath, _library.name))
             return
 
-        self.load_cores(library)
+        self._load_cores(library)
         self._lm.add_library(library)
 
     def get_libraries(self):

--- a/fusesoc/coremanager.py
+++ b/fusesoc/coremanager.py
@@ -210,6 +210,7 @@ class CoreManager:
                         logger.warning(w.format(core_file, str(e)))
 
     def add_library(self, library):
+        """ Register a library """
         abspath = os.path.abspath(os.path.expanduser(library.location))
         _library = self._lm.get_library(abspath, "location")
         if _library:
@@ -221,9 +222,19 @@ class CoreManager:
         self._lm.add_library(library)
 
     def get_libraries(self):
+        """ Get all registered libraries """
         return self._lm.get_libraries()
 
     def get_depends(self, core, flags):
+        """ Get an ordered list of all dependencies of a core
+
+        All direct and indirect dependencies are resolved into a dependency
+        tree, the tree is flattened, and an ordered list of dependencies is
+        created.
+
+        The first element in the list is a leaf dependency, the last element
+        is the core at the root of the dependency tree.
+        """
         logger.debug(
             "Calculating dependencies for {}{} with flags {}".format(
                 core.relation, str(core), str(flags)
@@ -236,14 +247,17 @@ class CoreManager:
         return deps
 
     def get_cores(self):
+        """ Get a dict with all cores, indexed by the core name """
         return {str(x.name): x for x in self.db.find()}
 
     def get_core(self, name):
+        """ Get a core with a given name """
         c = self.db.find(name)
         c.name.relation = "=="
         return c
 
     def get_generators(self):
+        """ Get a dict with all registered generators, indexed by name """
         generators = {}
         for core in self.db.find():
             if hasattr(core, "get_generators"):

--- a/fusesoc/edalizer.py
+++ b/fusesoc/edalizer.py
@@ -58,7 +58,7 @@ class Edalizer:
             _flags["is_toplevel"] = core.name == vlnv
 
             # Extract direct dependencies
-            snippet["dependencies"] = {str(core.name): getattr(core, "direct_deps", [])}
+            snippet["dependencies"] = {str(core.name): core.direct_deps}
 
             # Extract files
             if export_root:

--- a/fusesoc/edalizer.py
+++ b/fusesoc/edalizer.py
@@ -5,6 +5,7 @@ import shutil
 
 from fusesoc import utils
 from fusesoc.vlnv import Vlnv
+from fusesoc.utils import merge_dict
 
 logger = logging.getLogger(__name__)
 
@@ -38,16 +39,6 @@ class Edalizer:
             os.makedirs(work_root)
 
         logger.debug("Building EDA API")
-
-        def merge_dict(d1, d2):
-            for key, value in d2.items():
-                if isinstance(value, dict):
-                    d1[key] = merge_dict(d1.get(key, {}), value)
-                elif isinstance(value, list):
-                    d1[key] = d1.get(key, []) + value
-                else:
-                    d1[key] = value
-            return d1
 
         generators = {}
 

--- a/fusesoc/utils.py
+++ b/fusesoc/utils.py
@@ -139,3 +139,14 @@ def yaml_fread(filepath):
 
 def yaml_read(data):
     return yaml.load(data, Loader=YamlLoader)
+
+
+def merge_dict(d1, d2):
+    for key, value in d2.items():
+        if isinstance(value, dict):
+            d1[key] = merge_dict(d1.get(key, {}), value)
+        elif isinstance(value, list):
+            d1[key] = d1.get(key, []) + value
+        else:
+            d1[key] = value
+    return d1

--- a/tests/capi2_cores/deptree/child1.core
+++ b/tests/capi2_cores/deptree/child1.core
@@ -1,0 +1,16 @@
+CAPI=2:
+name: ::deptree-child1
+
+filesets:
+  fs1:
+    depend:
+      - ::deptree-child3
+    files:
+      - "child1-fs1-f1.sv"
+      - "child1-fs1-f2.sv"
+    fileType: systemVerilogSource
+
+targets:
+  default:
+    filesets:
+      - fs1

--- a/tests/capi2_cores/deptree/child2.core
+++ b/tests/capi2_cores/deptree/child2.core
@@ -1,0 +1,14 @@
+CAPI=2:
+name: ::deptree-child2
+
+filesets:
+  fs1:
+    files:
+      - "child2-fs1-f1.sv"
+      - "child2-fs1-f2.sv"
+    fileType: systemVerilogSource
+
+targets:
+  default:
+    filesets:
+      - fs1

--- a/tests/capi2_cores/deptree/child3.core
+++ b/tests/capi2_cores/deptree/child3.core
@@ -1,0 +1,14 @@
+CAPI=2:
+name: ::deptree-child3
+
+filesets:
+  fs1:
+    files:
+      - "child3-fs1-f1.sv"
+      - "child3-fs1-f2.sv"
+    fileType: systemVerilogSource
+
+targets:
+  default:
+    filesets:
+      - fs1

--- a/tests/capi2_cores/deptree/root.core
+++ b/tests/capi2_cores/deptree/root.core
@@ -1,0 +1,28 @@
+CAPI=2:
+name: ::deptree-root
+
+filesets:
+  fs1:
+    depend:
+      # Child 3 is also included from child1; having it listed first here should
+      # ensure that the files from child3 appear before the files from child2.
+      - ::deptree-child3
+      - ::deptree-child2
+      - ::deptree-child1
+    files:
+      - "root-fs1-f1.sv"
+      - "root-fs1-f2.sv"
+    fileType: systemVerilogSource
+  fs2:
+    depend:
+      - ::deptree-child3
+    files:
+      - "root-fs2-f1.sv"
+      - "root-fs2-f2.sv"
+    fileType: systemVerilogSource
+
+targets:
+  default:
+    filesets:
+      - fs1
+      - fs2

--- a/tests/test_coremanager.py
+++ b/tests/test_coremanager.py
@@ -1,6 +1,53 @@
 import pytest
 
 
+def test_deptree():
+    from fusesoc.coremanager import CoreManager
+    from fusesoc.config import Config
+    from fusesoc.librarymanager import Library
+    from fusesoc.vlnv import Vlnv
+    import os
+
+    tests_dir = os.path.dirname(__file__)
+    deptree_cores_dir = os.path.join(tests_dir, "capi2_cores", "deptree")
+    lib = Library("deptree", deptree_cores_dir)
+
+    cm = CoreManager(Config())
+    cm.add_library(lib)
+
+    root_core = cm.get_core(Vlnv("::deptree-root"))
+
+    # Check dependency tree
+    deps = cm.get_depends(root_core.name, {})
+    deps_names = [str(c) for c in deps]
+    deps_names_expected = [
+        "::deptree-child2:0",
+        "::deptree-child3:0",
+        "::deptree-child1:0",
+        "::deptree-root:0",
+    ]
+    assert deps_names == deps_names_expected
+
+    # Check files in dependency tree
+    files_expected = [
+        "child2-fs1-f1.sv",
+        "child2-fs1-f2.sv",
+        "child3-fs1-f1.sv",
+        "child3-fs1-f2.sv",
+        "child1-fs1-f1.sv",
+        "child1-fs1-f2.sv",
+        "root-fs1-f1.sv",
+        "root-fs1-f2.sv",
+        "root-fs2-f1.sv",
+        "root-fs2-f2.sv",
+    ]
+    files = []
+    for d in deps:
+        files += [f.name for f in d.get_files({})]
+
+    assert files == files_expected
+
+
 def test_copyto():
     import os
     import tempfile


### PR DESCRIPTION
* Add a simple test for the dependency resolution in CoreManager
* Make `CoreManager.load_cores()` private.
* Document the API of CoreManager better.

See the individual commit messages for more details.