### PR TITLE
Add command to draw a dependency graph

### DIFF
--- a/fusesoc/coremanager.py
+++ b/fusesoc/coremanager.py
@@ -12,6 +12,8 @@ from simplesat.request import Request
 
 from fusesoc.core import Core
 from fusesoc.librarymanager import LibraryManager
+from fusesoc.vlnv import Vlnv
+from fusesoc.utils import merge_dict
 
 logger = logging.getLogger(__name__)
 
@@ -234,6 +236,27 @@ class CoreManager:
         logger.debug(" Resolved core to {}".format(str(resolved_core.name)))
         logger.debug(" with dependencies " + ", ".join([str(c.name) for c in deps]))
         return deps
+
+    def get_dependency_graph(self, core_vlnv, flags, is_toplevel=True):
+        """ Generate a dependency graph
+
+        The graph is represented as flat dict. The key is the core, the value
+        is a set of dependencies.
+        """
+        graph = {}
+        core = self.get_core(core_vlnv)
+        deps = core.get_depends({**flags, "is_toplevel": is_toplevel})
+        for dep in deps:
+            # Find a core matching |dep| in the core library.
+            dep_core = self.get_core(dep).name
+
+            # Insert it into the graph.
+            merge_dict(graph, {core: {dep_core}})
+
+            # Find and insert all child dependencies recursively.
+            child_deps = self.get_dependency_graph(dep_core, flags, is_toplevel=False)
+            merge_dict(graph, child_deps)
+        return graph
 
     def get_cores(self):
         return {str(x.name): x for x in self.db.find()}

--- a/fusesoc/edalizer.py
+++ b/fusesoc/edalizer.py
@@ -5,6 +5,7 @@ import shutil
 
 from fusesoc import utils
 from fusesoc.vlnv import Vlnv
+from fusesoc.utils import merge_dict
 
 logger = logging.getLogger(__name__)
 
@@ -38,16 +39,6 @@ class Edalizer:
             os.makedirs(work_root)
 
         logger.debug("Building EDA API")
-
-        def merge_dict(d1, d2):
-            for key, value in d2.items():
-                if isinstance(value, dict):
-                    d1[key] = merge_dict(d1.get(key, {}), value)
-                elif isinstance(value, list):
-                    d1[key] = d1.get(key, []) + value
-                else:
-                    d1[key] = value
-            return d1
 
         generators = {}
 

--- a/fusesoc/main.py
+++ b/fusesoc/main.py
@@ -176,6 +176,60 @@ def init(cm, args):
     logger.info("FuseSoC is ready to use!")
 
 
+def dep_graph(cm, args):
+    flags = {"target": args.target, "tool": args.tool}
+    core_vlnv = Vlnv(args.core)
+
+    flags_str = ", ".join([k + "=" + v for k, v in flags.items() if v])
+    print(
+        "Building dependency graph for {core} with flags {flags}.".format(
+            core=args.core, flags=flags_str
+        )
+    )
+    core_graph = cm.get_dependency_graph(core_vlnv, flags)
+
+    dot_filepath = core_vlnv.sanitized_name + ".dot"
+    converted_output_filepath = (
+        core_vlnv.sanitized_name + "." + args.output_format.lower()
+    )
+
+    with open(dot_filepath, "w") as f:
+        f.write("digraph dependencies {\n")
+        for core, deps in core_graph.items():
+            for dep in deps:
+                f.write('"{}"->"{}"\n'.format(core, dep))
+        f.write("}\n")
+
+    if args.output_format != "dot":
+        dot_cmd = [
+            "dot",
+            "-T",
+            args.output_format,
+            "-o",
+            converted_output_filepath,
+            dot_filepath,
+        ]
+        try:
+            subprocess.run(dot_cmd)
+        except subprocess.CalledProcessError as e:
+            logger.fatal(
+                "Unable to call dot to convert dependency graph. "
+                "Install graphviz (which includes dot) and try again."
+            )
+            print(
+                "Kept graph in a dot file at {}. You can manually convert it "
+                "by running {}".format(dot_filepath),
+                " ".join(dot_cmd),
+            )
+            sys.exit(1)
+
+        # Remove the dot file if the conversion went well.
+        os.unlink(dot_filepath)
+    print(
+        "Successfully written dependency graph to {}.".format(converted_output_filepath)
+    )
+
+
 def list_paths(cm, args):
     cores_root = [x.location for x in cm.get_libraries()]
     print("\n".join(cores_root))
@@ -811,6 +865,35 @@ def parse_args():
     parser_update.set_defaults(
         warn="'fusesoc update' is deprecated. Use 'fusesoc library update' instead"
     )
+
+    # dep subparser
+    parser_dep = subparsers.add_parser("dep", help="Subcommands dependency management")
+    dep_subparsers = parser_dep.add_subparsers()
+    parser_dep.set_defaults(subparser=parser_dep)
+
+    # dep graph subparser
+    parser_dep_graph = dep_subparsers.add_parser(
+        "graph", help="Produce a dependency graph for GraphViz"
+    )
+    parser_dep_graph.add_argument(
+        "core", help="Core to build the dependency graph for."
+    )
+    parser_dep_graph.add_argument(
+        "--target", help="Target to build the dependency graph for.", default="default"
+    )
+    parser_dep_graph.add_argument(
+        "--tool", help="Tool to build the dependency graph for.", default=""
+    )
+    parser_dep_graph.add_argument(
+        "--output-format",
+        help=(
+            "Convert output into desired format (requires dot). "
+            "All dot-supported formats can be used, run 'dot -T?' for a "
+            "complete list."
+        ),
+        default="dot",
+    )
+    parser_dep_graph.set_defaults(func=dep_graph)
 
     args = parser.parse_args()
 

--- a/fusesoc/utils.py
+++ b/fusesoc/utils.py
@@ -139,3 +139,14 @@ def yaml_fread(filepath):
 
 def yaml_read(data):
     return yaml.load(data, Loader=YamlLoader)
+
+
+def merge_dict(d1, d2):
+    for key, value in d2.items():
+        if isinstance(value, dict):
+            d1[key] = merge_dict(d1.get(key, {}), value)
+        elif isinstance(value, list):
+            d1[key] = d1.get(key, []) + value
+        else:
+            d1[key] = value
+    return d1

--- a/fusesoc/utils.py
+++ b/fusesoc/utils.py
@@ -147,6 +147,8 @@ def merge_dict(d1, d2):
             d1[key] = merge_dict(d1.get(key, {}), value)
         elif isinstance(value, list):
             d1[key] = d1.get(key, []) + value
+        elif isinstance(value, set):
+            d1[key] = d1.get(key, set()) | value
         else:
             d1[key] = value
     return d1


### PR DESCRIPTION
The new command `fusesoc dep graph` creates a GraphViz .dot file
listing all dependencies for a given core with given flags. This file
can be either manually converted into an image using the `dot` tool
(part of the GraphViz package), or automatically converted with FuseSoC
through the `--output-format` command line option.

Full documentation:

```
$ fusesoc dep graph --help
usage: fusesoc dep graph [-h] [--target TARGET] [--tool TOOL] [--output-format OUTPUT_FORMAT] core

positional arguments:
  core                  Core to build the dependency graph for.

optional arguments:
  -h, --help            show this help message and exit
  --target TARGET       Target to build the dependency graph for.
  --tool TOOL           Tool to build the dependency graph for.
  --output-format OUTPUT_FORMAT
                        Convert output into desired format (requires dot). All dot-supported formats can be used, run 'dot -T?' for a complete list.
```

Based on inital work by Stefan Wallentowitz in #99

Fixes #98