### PR TITLE
Don't re-parse arguemnts in run

### DIFF
--- a/fusesoc/main.py
+++ b/fusesoc/main.py
@@ -478,7 +478,7 @@ def run_backend(
 
     if do_run:
         try:
-            backend.run(backendargs)
+            backend.run([])
         except RuntimeError as e:
             logger.error("Failed to run {} : {}".format(str(core.name), str(e)))
             exit(1)


### PR DESCRIPTION
At present, with FuseSoC and Edalize at master, any backend arguments that take strings as parameters get truncated to their first character. I think the re-parse is unnecessary, as everything is done once at the beginning, and the bug is shown only in a re-parse during the run step.

I think this is a change that was missing in https://github.com/olofk/fusesoc/issues/363 - I've tried a few things locally with no problems, but I don't tend to use arguments relevant to the run step, so I'd appreciate others' opinions.