### PR TITLE
Use Python 3 in generators.core example

### DIFF
--- a/tests/capi2_cores/misc/generators.core
+++ b/tests/capi2_cores/misc/generators.core
@@ -3,5 +3,5 @@ name: ::generators:0
 
 generators:
   generator1:
-    interpreter: python
+    interpreter: python3
     command: testgen.py


### PR DESCRIPTION
Otherwise running the testsuite has a dependency on (at least) the
yaml library for Python 2.