### PR TITLE
Don't use a class variable for _libraries in LibraryManager

### DIFF
--- a/fusesoc/librarymanager.py
+++ b/fusesoc/librarymanager.py
@@ -57,9 +57,8 @@ class Library:
 
 
 class LibraryManager:
-    _libraries = []
-
     def __init__(self, library_root):
+        self._libraries = []
         self.library_root = library_root
 
     def add_library(self, library):


### PR DESCRIPTION
This should have no effect when running the fusesoc program, but the
class variable can cause problems with test code (which doesn't
restart Python between different tests) because different the state
hangs around.