### PR TITLE
Stringify args for calls to debug prints and subprocess

### DIFF
--- a/fusesoc/utils.py
+++ b/fusesoc/utils.py
@@ -27,7 +27,7 @@ class Launcher:
         logger.debug("    " + str(self))
         try:
             subprocess.check_call(
-                [self.cmd] + self.args, cwd=self.cwd, stdin=subprocess.PIPE
+                map(str, [self.cmd] + self.args), cwd=self.cwd, stdin=subprocess.PIPE
             ),
         except FileNotFoundError:
             raise RuntimeError(
@@ -38,7 +38,7 @@ class Launcher:
             raise RuntimeError(self.errormsg.format(str(self)))
 
     def __str__(self):
-        return " ".join([self.cmd] + self.args)
+        return " ".join(map(str, [self.cmd] + self.args))
 
 
 def is_mingw():

--- a/fusesoc/utils.py
+++ b/fusesoc/utils.py
@@ -23,6 +23,8 @@ class Launcher:
         self.cwd = cwd
 
     def run(self):
+        """Runs the cmd with args after converting them all to strings via str
+        """
         logger.debug(self.cwd)
         logger.debug("    " + str(self))
         try:


### PR DESCRIPTION
Whilst changing a core file I use from CAPI1 to CAPI2 I discovered some odd datatype behaviour that causes python to throw an exception in the utils.py file. 

Previously I used a CAPI1 core file with the name 'somecore-2019.11.core' representing version 2019.11 of 'somecore', using the year.month versioning scheme. With a new release, I thought I'd upgrade the core file to a CAPI2 one with a git provider section like:

```
provider:
  name: git
  repo: some_legal_git_url
  version: 2020.01
```

Unfortunately, this fails to check out because the version field is interpreted by the YAML safe_load function in capi2/core.py as a float. This gets passed through to the utils file whose
calls to join and check_call error as they expect strings and not floats.

This change makes sure that string representations of objects are used in the call to subprocess and join. I tried to work out if there was a better way of doing this earlier when the self.config object is created, but I'm afraid I got lost in the code. Does this seem a reasonable approach?