### PR TITLE
Fix regression in the file order of designs with generators.

### DIFF
--- a/tests/capi2_cores/deptree/child1.core
+++ b/tests/capi2_cores/deptree/child1.core
@@ -12,7 +12,7 @@ filesets:
     files:
       - "child1-fs1-f1.sv"
       - "child1-fs1-f2.sv"
-    fileType: systemVerilogSource
+    file_type: systemVerilogSource
 
 targets:
   default:

--- a/tests/capi2_cores/deptree/child2.core
+++ b/tests/capi2_cores/deptree/child2.core
@@ -10,7 +10,7 @@ filesets:
     files:
       - "child2-fs1-f1.sv"
       - "child2-fs1-f2.sv"
-    fileType: systemVerilogSource
+    file_type: systemVerilogSource
 
 targets:
   default:

--- a/tests/capi2_cores/deptree/child3.core
+++ b/tests/capi2_cores/deptree/child3.core
@@ -10,7 +10,7 @@ filesets:
     files:
       - "child3-fs1-f1.sv"
       - "child3-fs1-f2.sv"
-    fileType: systemVerilogSource
+    file_type: systemVerilogSource
 
 targets:
   default:

--- a/tests/capi2_cores/deptree/child4.core
+++ b/tests/capi2_cores/deptree/child4.core
@@ -1,0 +1,17 @@
+CAPI=2:
+# Copyright FuseSoC contributors
+# Licensed under the 2-Clause BSD License, see LICENSE for details.
+# SPDX-License-Identifier: BSD-2-Clause
+
+name: ::deptree-child4
+
+filesets:
+  fs1:
+    files:
+      - "child4.sv"
+    file_type: systemVerilogSource
+
+targets:
+  default:
+    filesets:
+      - fs1

--- a/tests/capi2_cores/deptree/generated_child_a.core
+++ b/tests/capi2_cores/deptree/generated_child_a.core
@@ -1,0 +1,31 @@
+CAPI=2:
+# Copyright FuseSoC contributors
+# Licensed under the 2-Clause BSD License, see LICENSE for details.
+# SPDX-License-Identifier: BSD-2-Clause
+
+name: ::deptree-child-a
+
+filesets:
+  fs1:
+    files:
+      - "child-a2.sv"
+    file_type: systemVerilogSource
+
+    depend:
+      - ::deptree-child4
+
+generate:
+  generated-child-a-generate:
+    generator: generated-child-a-generator
+
+generators:
+  generated-child-a-generator:
+    interpreter: python3
+    command: generated_child_a.py
+
+targets:
+  default:
+    filesets:
+      - fs1
+    generate:
+      - generated-child-a-generate

--- a/tests/capi2_cores/deptree/generated_child_a.py
+++ b/tests/capi2_cores/deptree/generated_child_a.py
@@ -1,0 +1,17 @@
+# Copyright FuseSoC contributors
+# Licensed under the 2-Clause BSD License, see LICENSE for details.
+# SPDX-License-Identifier: BSD-2-Clause
+
+from fusesoc.capi2.generator import Generator
+
+
+class MacroGenerator(Generator):
+    def run(self):
+        self.vlnv = "::generated-child-a"
+        self.add_files(["generated-child-a.sv"], file_type="systemVerilogSource")
+
+
+if __name__ == "__main__":
+    g = MacroGenerator()
+    g.run()
+    g.write()

--- a/tests/capi2_cores/deptree/root.core
+++ b/tests/capi2_cores/deptree/root.core
@@ -16,14 +16,14 @@ filesets:
     files:
       - "root-fs1-f1.sv"
       - "root-fs1-f2.sv"
-    fileType: systemVerilogSource
+    file_type: systemVerilogSource
   fs2:
     depend:
       - ::deptree-child3
     files:
       - "root-fs2-f1.sv"
       - "root-fs2-f2.sv"
-    fileType: systemVerilogSource
+    file_type: systemVerilogSource
 
 targets:
   default:

--- a/tests/capi2_cores/deptree/root.core
+++ b/tests/capi2_cores/deptree/root.core
@@ -8,8 +8,10 @@ name: ::deptree-root
 filesets:
   fs1:
     depend:
-      # Child 3 is also included from child1; having it listed first here should
-      # ensure that the files from child3 appear before the files from child2.
+      # Child 3 is also included from child 1.
+      # The only effect of that, is that we would expect the child 3 files
+      # always to be included before the child 1 files.
+      - ::deptree-child-a
       - ::deptree-child3
       - ::deptree-child2
       - ::deptree-child1
@@ -30,3 +32,5 @@ targets:
     filesets:
       - fs1
       - fs2
+    toplevel:
+      - root


### PR DESCRIPTION
Recent refactoring of the Edalizer class introduced a bug where the files in the generated .eda are not in a dependency-consistent order.

This fixes this bug, by keeping track of how the generated cores are positioned in the ordered list of cores.