### PR TITLE
The pipe to the stdin of the Launcher process is removed. The pipe is…

### DIFF
--- a/fusesoc/utils.py
+++ b/fusesoc/utils.py
@@ -33,7 +33,7 @@ class Launcher:
         logger.debug("    " + str(self))
         try:
             subprocess.check_call(
-                map(str, [self.cmd] + self.args), cwd=self.cwd, stdin=subprocess.PIPE
+                map(str, [self.cmd] + self.args), cwd=self.cwd,
             ),
         except FileNotFoundError:
             raise RuntimeError(


### PR DESCRIPTION
… not used, and it gets in the way of debugging the generator using stdin (i.e. pdb breakpoint in generator).

I didn't see any reason for this pipe so I'm assuming it's use is historical.  I often do pdb debugging of the generators and make this modification locally so that I can communicate with the generators using stdin like normal.