### PR TITLE
Let os.makedirs handle existing directories.

### DIFF
--- a/fusesoc/capi2/core.py
+++ b/fusesoc/capi2/core.py
@@ -220,8 +220,7 @@ class Core:
 
         dirs = list(set(map(os.path.dirname, src_files)))
         for d in dirs:
-            if not os.path.exists(os.path.join(dst_dir, d)):
-                os.makedirs(os.path.join(dst_dir, d))
+            os.makedirs(os.path.join(dst_dir, d), exist_ok=True)
 
         for f in src_files:
             if not os.path.isabs(f):


### PR DESCRIPTION
In some cases os.path.exists may return False,
even if the path exists. In such scenarios running
FuseSoc results with FileExistsError. Letting
os.makedirs handle existing directories avoid such
buggy corner cases.