### PR TITLE
Catch error when backend tool is unknown

### DIFF
--- a/fusesoc/main.py
+++ b/fusesoc/main.py
@@ -412,7 +412,11 @@ def run_backend(
     if not os.path.exists(eda_api_file):
         do_configure = True
 
-    backend_class = get_edatool(tool)
+    try:
+        backend_class = get_edatool(tool)
+    except ImportError:
+        logger.error("Backend {!r} not found".format(tool))
+        exit(1)
 
     edalizer = Edalizer(
         toplevel=core.name,
@@ -445,11 +449,8 @@ def run_backend(
     # Frontend/backend separation
 
     try:
-        backend = get_edatool(tool)(edam=edam, work_root=work_root)
+        backend = backend_class(edam=edam, work_root=work_root)
 
-    except ImportError:
-        logger.error('Backend "{}" not found'.format(tool))
-        exit(1)
     except RuntimeError as e:
         logger.error(str(e))
         exit(1)


### PR DESCRIPTION
We were calling `get_edatool(tool)` twice: once for parsing backend
arguments and then again to do the actual work. The first call wasn't
surrounded by a try/catch for `ImportError`. This meant that if you
asked for a bogus tool (with a typo in your corefile), a
`ModuleNotFoundError` would make it to the console.

This patch surrounds the call to `get_edatool` with the try/catch block.
It also uses the `backend_class` that we found, rather than calling
`get_edatool` again.