### PR TITLE
Add support for specifying library version

### DIFF
--- a/fusesoc/config.py
+++ b/fusesoc/config.py
@@ -115,18 +115,13 @@ class Config:
                 logger.warning(_s.format(str(e), name))
                 continue
 
-            try:
-                sync_uri = config.get(section, "sync-uri")
-            except configparser.NoOptionError:
-                # sync-uri is absent for local libraries
-                sync_uri = None
+            sync_uri = config.get(section, "sync-uri", None)
+            sync_version = config.get(section, "sync-version", None)
+            sync_type = config.get(section, "sync-type", None)
 
-            try:
-                sync_type = config.get(section, "sync-type")
-            except configparser.NoOptionError:
-                # sync-uri is absent for local libraries
-                sync_type = None
-            libraries.append(Library(name, location, sync_type, sync_uri, auto_sync))
+            libraries.append(
+                Library(name, location, sync_type, sync_uri, sync_version, auto_sync)
+            )
         # Get the environment variable for further cores
         env_cores_root = []
         if os.getenv("FUSESOC_CORES"):
@@ -165,6 +160,10 @@ class Config:
 
         if library.sync_type:
             config.set(section_name, "sync-uri", library.sync_uri)
+
+            if library.sync_version is not None:
+                config.set(section_name, "sync-version", library.sync_version)
+
             config.set(section_name, "sync-type", library.sync_type)
             _auto_sync = "true" if library.auto_sync else "false"
             config.set(section_name, "auto-sync", _auto_sync)

--- a/fusesoc/config.py
+++ b/fusesoc/config.py
@@ -115,9 +115,9 @@ class Config:
                 logger.warning(_s.format(str(e), name))
                 continue
 
-            sync_uri = config.get(section, "sync-uri", None)
-            sync_version = config.get(section, "sync-version", None)
-            sync_type = config.get(section, "sync-type", None)
+            sync_uri = config.get(section, "sync-uri", fallback=None)
+            sync_version = config.get(section, "sync-version", fallback=None)
+            sync_type = config.get(section, "sync-type", fallback=None)
 
             libraries.append(
                 Library(name, location, sync_type, sync_uri, sync_version, auto_sync)

--- a/fusesoc/librarymanager.py
+++ b/fusesoc/librarymanager.py
@@ -11,7 +11,15 @@ logger = logging.getLogger(__name__)
 
 
 class Library:
-    def __init__(self, name, location, sync_type=None, sync_uri=None, auto_sync=True):
+    def __init__(
+        self,
+        name,
+        location,
+        sync_type=None,
+        sync_uri=None,
+        sync_version=None,
+        auto_sync=True,
+    ):
         if sync_type and not sync_type in ["local", "git"]:
             raise ValueError(
                 "Library {} ({}) Invalid sync-type '{}'".format(
@@ -31,6 +39,7 @@ class Library:
         self.location = location
         self.sync_type = sync_type or "local"
         self.sync_uri = sync_uri
+        self.sync_version = sync_version
         self.auto_sync = auto_sync
 
     def update(self, force=False):

--- a/fusesoc/main.py
+++ b/fusesoc/main.py
@@ -158,7 +158,7 @@ def init(cm, args):
         else:
             logger.info("Initializing {}".format(name))
             try:
-                library = Library(name, location, "git", uri, True)
+                library = Library(name, location, "git", uri, None, True)
                 config.add_library(library)
             except RuntimeError as e:
                 logger.error("Init failed: " + str(e))
@@ -181,10 +181,8 @@ def add_library(cm, args):
     else:
         location = os.path.join("fusesoc_libraries", args.name)
 
-    if "sync-type" in vars(args):
-        sync_type = vars(args)["sync-type"]
-    else:
-        sync_type = None
+    sync_type = vars(args).get("sync-type")
+    sync_version = vars(args).get("sync-version")
 
     # Check if it's a dir. Otherwise fall back to git repo
     if not sync_type:
@@ -202,7 +200,7 @@ def add_library(cm, args):
         location = os.path.abspath(sync_uri)
 
     auto_sync = not args.no_auto_sync
-    library = Library(args.name, location, sync_type, sync_uri, auto_sync)
+    library = Library(args.name, location, sync_type, sync_uri, sync_version, auto_sync)
 
     if args.config:
         config = Config(file=args.config)
@@ -223,29 +221,32 @@ def add_library(cm, args):
 
 
 def library_list(cm, args):
-    lengths = [4, 8, 9, 8, 9]
+    lengths = [4, 8, 9, 8, 12, 9]
     for lib in cm.get_libraries():
         lengths[0] = max(lengths[0], len(lib.name))
         lengths[1] = max(lengths[1], len(lib.location))
         lengths[2] = max(lengths[2], len(lib.sync_type))
         lengths[3] = max(lengths[3], len(lib.sync_uri or ""))
+        lengths[4] = max(lengths[4], len(lib.sync_version))
     print(
-        "{} : {} : {} : {} : {}".format(
+        "{} : {} : {} : {} : {} : {}".format(
             "Name".ljust(lengths[0]),
             "Location".ljust(lengths[1]),
             "Sync type".ljust(lengths[2]),
             "Sync URI".ljust(lengths[3]),
-            "Auto sync".ljust(lengths[4]),
+            "Sync version".ljust(lengths[4]),
+            "Auto sync".ljust(lengths[5]),
         )
     )
     for lib in cm.get_libraries():
         print(
-            "{} : {} : {} : {} : {}".format(
+            "{} : {} : {} : {} : {} : {}".format(
                 lib.name.ljust(lengths[0]),
                 lib.location.ljust(lengths[1]),
                 lib.sync_type.ljust(lengths[2]),
                 (lib.sync_uri or "N/A").ljust(lengths[3]),
-                ("y" if lib.auto_sync else "n").ljust(lengths[4]),
+                (lib.sync_version or "(none)").ljust(lengths[4]),
+                ("y" if lib.auto_sync else "n").ljust(lengths[5]),
             )
         )
 
@@ -670,6 +671,11 @@ def get_parser():
         "sync-uri", help="The URI source for the library (can be a file system path)"
     )
     parser_library_add.add_argument(
+        "--sync-version",
+        help="Optionally specify the version of the library to use, for providers that support it",
+        dest="sync-version",
+    )
+    parser_library_add.add_argument(
         "--location",
         help="The location to store the library into (defaults to $XDG_DATA_HOME/[name])",
     )
@@ -677,6 +683,7 @@ def get_parser():
         "--sync-type",
         help="The provider type for the library. Defaults to 'git'.",
         choices=["git", "local"],
+        dest="sync-type",
     )
     parser_library_add.add_argument(
         "--no-auto-sync",

--- a/fusesoc/provider/git.py
+++ b/fusesoc/provider/git.py
@@ -15,11 +15,24 @@ logger = logging.getLogger(__name__)
 
 class Git(Provider):
     @staticmethod
+    def _checkout_library_version(library):
+        git_args = ["-C", library.location, "checkout", "-q", library.sync_version]
+
+        if library.sync_version:
+            logger.info(
+                "Checkout out {} at version {}".format(
+                    library.name, library.sync_version
+                )
+            )
+            Launcher("git", git_args).run()
+
+    @staticmethod
     def init_library(library):
         logger.info("Cloning library into {}".format(library.location))
         git_args = ["clone", library.sync_uri, library.location]
         try:
             Launcher("git", git_args).run()
+            Git._checkout_library_version(library)
         except subprocess.CalledProcessError as e:
             raise RuntimeError(str(e))
 
@@ -27,6 +40,7 @@ class Git(Provider):
     def update_library(library):
         git_args = ["-C", library.location, "pull"]
         try:
+            Git._checkout_library_version(library)
             Launcher("git", git_args).run()
         except subprocess.CalledProcessError as e:
             raise RuntimeError(str(e))

--- a/fusesoc/utils.py
+++ b/fusesoc/utils.py
@@ -27,7 +27,7 @@ class Launcher:
 
     def run(self):
         """Runs the cmd with args after converting them all to strings via str"""
-        logger.debug(self.cwd)
+        logger.debug(self.cwd or "./")
         logger.debug("    " + str(self))
         try:
             subprocess.check_call(

--- a/tests/test_libraries.py
+++ b/tests/test_libraries.py
@@ -129,6 +129,32 @@ auto-sync = true"""
         in caplog.text
     )
 
+    tcf = tempfile.NamedTemporaryFile(mode="w+")
+    args.config = tcf
+
+    vars(args)["sync-type"] = "git"
+    vars(args)["sync-uri"] = sync_uri
+    vars(args)["sync-version"] = "capi2"
+    args.location = None
+
+    expected = """[library.fusesoc-cores]
+location = fusesoc_libraries/fusesoc-cores
+sync-uri = https://github.com/fusesoc/fusesoc-cores
+sync-version = capi2
+sync-type = git
+auto-sync = true""".format(
+        cm._lm.library_root
+    )
+
+    add_library(cm, args)
+
+    tcf.seek(0)
+    result = tcf.read().strip()
+
+    assert expected == result
+    shutil.rmtree("fusesoc_libraries")
+    tcf.close()
+
 
 def test_library_update(caplog):
     from fusesoc.main import init_coremanager, init_logging, update


### PR DESCRIPTION
This commit adds a new option sync-version to the config file and
the library subcommand for the cli tool. This option is passed through
to the provider used for a library to specify a version of the library
to use.
This change also updates the git provider to use the sync-version to
checkout a commitish on a git-provided library. This libraries to be
fixed at certian points, or follow specific branches (such as nightly or
stable)