### PR TITLE
Pass generator_input_file using absolute path to support relative cache_root settings

### DIFF
--- a/fusesoc/edalizer.py
+++ b/fusesoc/edalizer.py
@@ -402,7 +402,7 @@ class Ttptttg:
 
         args = [
             os.path.join(os.path.abspath(self.generator.root), self.generator.command),
-            generator_input_file,
+            os.path.abspath(generator_input_file),
         ]
 
         if self.generator.interpreter:


### PR DESCRIPTION
Whilst experimenting with relative cache_root's in our CI setup, I've stumbled across an incompatibility between generators and relative cache_root settings. 

If you provide a fusesoc.conf file that contains the following, then generators are unable to read their generator_input_file yaml file, as the filepath is described as relative to cache_root, whilst the working directory is inside the generator folder:

```
[main]
cache_root = ./relative-cache
```

By converting the generator_input_file path using the abspath function, the generators can find their input file even if the user has configured their fusesoc.conf file to specify a relative path to cache_root. If the cache_root is already fully specified, then this change has no effect.