### PR TITLE
CI: Run test in forked repo context

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,11 +13,11 @@ on:
 jobs:
   build-and-test:
     name: Build and Test (Python ${{ matrix.python-version }} on ${{ matrix.os }})
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         os:
-          - ubuntu-latest
+          - ubuntu-20.04
           - macos-latest
           - windows-latest
         python-version:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,9 +6,7 @@ on:
     branches:
       - master
 
-  # Run pull request CI in the context of the target (upstream, origin)
-  # repository, which gives more access to secrets.
-  pull_request_target:
+  pull_request:
     branches:
       - master
 
@@ -16,13 +14,6 @@ jobs:
   build-and-test:
     name: Build and Test (Python ${{ matrix.python-version }} on ${{ matrix.os }})
     runs-on: ubuntu-latest
-    # Always run on push events, but only run on the pull_request_target event
-    # when the pull request pulls from the fork repository. For pull requests
-    # within the same repository the pull event is sufficient.
-    if: >
-      github.event_name == 'push' ||
-      (github.event_name == 'pull_request_target'
-       && github.event.pull_request.head.repo.full_name != github.repository)
     strategy:
       matrix:
         os:
@@ -47,31 +38,6 @@ jobs:
     - name: Install Tox and any other packages
       run: pip install tox tox-gh-actions
     - name: Build package and run tests with tox
-      run: tox -- --junitxml=pytest-results.xml
-    - name: Upload Unit Test Results
-      if: always()
-      uses: actions/upload-artifact@v2
-      with:
-        name: Unit Test Results
-        path: pytest-results.xml
-
-  publish-test-results:
-    name: Publish Unit Tests Results
-    needs: build-and-test
-    runs-on: ubuntu-latest
-    # No test results need to be published if the build-and-test job is skipped.
-    if: success() || failure()
-
-    steps:
-      - name: Download Artifacts
-        uses: actions/download-artifact@v2
-        with:
-          path: artifacts
-
-      - name: Publish Unit Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v1.4
-        with:
-          check_name: Unit Test Results
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          files: pytest-results.xml
-          comment_on_pr: false
+      # XXX: Remove `-e py3-ci` and rely on the settings in tox.ini as soon as
+      # https://github.com/ymyzk/tox-gh-actions/issues/44 is resolved.
+      run: tox -e py3-ci

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   pre-commit:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-python@v2

--- a/fusesoc/edalizer.py
+++ b/fusesoc/edalizer.py
@@ -46,11 +46,14 @@ class Edalizer:
 
         self.generators = {}
 
-        self._generated_cores = []
+        self._resolved_or_generated_cores = []
 
     @property
     def cores(self):
-        return self.resolved_cores + self._generated_cores
+        if self._resolved_or_generated_cores:
+            return self._resolved_or_generated_cores
+        else:
+            return self.resolved_cores
 
     @property
     def resolved_cores(self):
@@ -129,10 +132,11 @@ class Edalizer:
 
     def run_generators(self):
         """ Run all generators """
+        self._resolved_or_generated_cores = []
         for core in self.cores:
             logger.debug("Running generators in " + str(core.name))
             core_flags = self._core_flags(core)
-
+            self._resolved_or_generated_cores.append(core)
             if hasattr(core, "get_ttptttg"):
                 for ttptttg_data in core.get_ttptttg(core_flags):
                     _ttptttg = Ttptttg(
@@ -142,7 +146,7 @@ class Edalizer:
                     )
                     for gen_core in _ttptttg.generate(self.cache_root):
                         gen_core.pos = _ttptttg.pos
-                        self._generated_cores.append(gen_core)
+                        self._resolved_or_generated_cores.append(gen_core)
 
     def create_eda_api_struct(self):
         first_snippets = []

--- a/tox.ini
+++ b/tox.ini
@@ -2,17 +2,22 @@
 envlist = py3
 
 [testenv]
+# Dependencies prefixed with "ci: " are only installed when running in CI,
+# which calls effectively "tox -e py3-ci" (see the gh-actions section below).
+deps =
+    pytest
+    ci: pytest-github-actions-annotate-failures
+
 # Some tests need an initialized FuseSoC library to be present. To make tests
 # reproducible tox doesn't use the library installed into the user's home
 # directory, but creates an isolated home directory within the tox working
 # directory, and clears it out after each test.
-deps = pytest
 commands =
     /bin/rm -rf {toxworkdir}/.tmp/homedir
     fusesoc init -y
     fusesoc list-cores
     fusesoc library update
-    pytest {posargs}
+    pytest {posargs:-vv}
 
 setenv =
     MODEL_TECH = dummy_value
@@ -21,15 +26,21 @@ setenv =
     XDG_DATA_HOME= {toxworkdir}/.tmp/homedir/.local/share
     XDG_CONFIG_HOME = {toxworkdir}/.tmp/homedir/.config
 
+passenv =
+    GITHUB_ACTIONS
+
 whitelist_externals =
   /bin/rm
 
 [gh-actions]
 # Mapping between the Python version used in GitHub Actions matrix builds, and
 # the used Tox environment.
+# XXX: This setting is currently overwritten on the command line for CI builds
+# (see the pipeline configuration) due to
+# https://github.com/ymyzk/tox-gh-actions/issues/44.
 python =
-    3.5: py3
-    3.6: py3
-    3.7: py3
-    3.8: py3
-    3.9: py3
+    3.5: py3-ci
+    3.6: py3-ci
+    3.7: py3-ci
+    3.8: py3-ci
+    3.9: py3-ci


### PR DESCRIPTION
Right now, we run pull request CI jobs in the context of the olofk/fusesoc
repository. We did this to be able to create Check runs, which show the
pytest results in the GitHub UI. There are multiple problems with that:

First, the runs actually didn't contain any data. That's probably fixable
if we found the right configuration regarding test result files and
artifacts.

Second, and more importantly, it seems that the "old" test code was run, 
i.e. pytest didn't pick up test changes done in the PR. That's hard to 
believe, but also not very useful, as PRs often modify code and tests at 
the same time. There might be some misconfiguration going on somewhere, but
I didn't debug it fully.

Finally, the test result reporting action we used is actually rather slow
(significantly slower than the test runs themselves), as it creates and
then runs a Docker container.

In this commit, we try a different approach and annotate the source code 
with test results.