### PR TITLE
Test the position attribute for generate blocks

### DIFF
--- a/tests/capi2_cores/deptree/generated_child_a.core
+++ b/tests/capi2_cores/deptree/generated_child_a.core
@@ -17,6 +17,26 @@ filesets:
 generate:
   generated-child-a-generate:
     generator: generated-child-a-generator
+    parameters:
+      filename: generated-child-a.sv
+
+  generated-child-a-generate-position-append:
+    generator: generated-child-a-generator
+    parameters:
+      filename: generated-child-a-append.sv
+    position: append
+
+  generated-child-a-generate-position-last:
+    generator: generated-child-a-generator
+    parameters:
+      filename: generated-child-a-last.sv
+    position: last
+
+  generated-child-a-generate-position-first:
+    generator: generated-child-a-generator
+    parameters:
+      filename: generated-child-a-first.sv
+    position: first
 
 generators:
   generated-child-a-generator:
@@ -29,3 +49,6 @@ targets:
       - fs1
     generate:
       - generated-child-a-generate
+      - generated-child-a-generate-position-append
+      - generated-child-a-generate-position-last
+      - generated-child-a-generate-position-first

--- a/tests/capi2_cores/deptree/generated_child_a.py
+++ b/tests/capi2_cores/deptree/generated_child_a.py
@@ -7,8 +7,8 @@ from fusesoc.capi2.generator import Generator
 
 class MacroGenerator(Generator):
     def run(self):
-        self.vlnv = "::generated-child-a"
-        self.add_files(["generated-child-a.sv"], file_type="systemVerilogSource")
+        assert self.config["filename"]
+        self.add_files([self.config["filename"]], file_type="systemVerilogSource")
 
 
 if __name__ == "__main__":

--- a/tests/test_coremanager.py
+++ b/tests/test_coremanager.py
@@ -56,12 +56,13 @@ def test_deptree(tmp_path):
         "::deptree-child4:0": ("child4.sv",),
         "::deptree-child-a:0": (
             # Files from filesets are always included before any
-            # files from generators.
+            # files from generators with "position: append".
             # This is because generated files are often dependent on files
             # that are not generated, and it convenient to be able to
             # include them in the same core.
             "child-a2.sv",
             "generated-child-a.sv",
+            "generated-child-a-append.sv",
         ),
         "::deptree-root:0": (
             "root-fs1-f1.sv",
@@ -106,8 +107,12 @@ def test_deptree(tmp_path):
     # Each fileset in order. Followed by each generator in order.
     # The order between the cores is taken the above `dep_names`.
     expected_filenames = []
+    # A generator-created core with "position: first"
+    expected_filenames.append("generated-child-a-first.sv")
     for dep_name in deps_names:
         expected_filenames += list(expected_core_files[dep_name])
+    # A generator-created core with "position: last"
+    expected_filenames.append("generated-child-a-last.sv")
 
     edalized_filenames = [
         os.path.basename(f["name"]) for f in edalizer.edalize["files"]


### PR DESCRIPTION
The position attriute is meant to insert files generated by the core at
a specific location: after the chosen core, at the beginning of the file
list, or at the end. This behavior was not tested so far. Add a test for
it.