### PR TITLE
Fix markup in CAPI1 documentation

### DIFF
--- a/doc/source/ref/capi1.rst
+++ b/doc/source/ref/capi1.rst
@@ -1,310 +1,894 @@
+******************
 CAPI1 (deprecated)
-==================
+******************
 
+.. _type_definitions:
 
 Type definitions
-----------------
+================
 
-[[File]] File ~~~~ File objects consist of a mandatory file name, with
-path relative to the core root. Extra options can be specified as a
-comma-separated list enclosed in [] after the file name. Options are
-either boolean (option) or has a value (option=value). No white-space is
-allowed anywhere in the file object
+.. _File:
+
+File
+----
+
+File objects consist of a mandatory file name, with path relative to the
+core root. Extra options can be specified as a comma-separated list
+enclosed in ``[]`` after the file name. Options are either boolean (``option``)
+or has a value (``option=value``). No white-space is allowed anywhere in the
+file object.
 
 The following options are defined:
 
--  *file_type :* Value can be any type defined in <<FileTypes, File
-   types>>
+-  **file_type :** Value can be any type defined in `File
+   types <#FileTypes>`__
 
--  *is_include_file :* Boolean value to indicate this should be treated
-   as an include file
+-  **is_include_file :** Boolean value to indicate this should be
+   treated as an include file
 
--  *logical_name :* Indicate that the file belongs to a logical unit
-   (e.g. VHDL Library) with the name set by the value
--  *copyto :* Indicate that the file should be copied to a new location
-   relative to the work root.
+-  **logical_name :** Indicate that the file belongs to a logical unit
+   (e.g. VHDL Library) with the name set by the value
+
+-  **copyto :** Indicate that the file should be copied to a new
+   location relative to the work root.
 
 Example:
-rtl/verilog/uart_defines.v[file_type=verilogSource,is_include_file]
+``rtl/verilog/uart_defines.v[file_type=verilogSource,is_include_file]``
 
-Example: data/mem_init_file.bin[copyto=out/boot.bin]
+Example: ``data/mem_init_file.bin[copyto=out/boot.bin]``
 
-[[FileList]] FileList ~~~~~~~~ Space-separated list of <>
+.. _FileList:
+
+FileList
+--------
+
+Space-separated list of `File <#File>`__
 
 Each element in the list is first subjected to the expansion according
-to <> and then parsed as a <>
+to `PathList <#PathList>`__ and then parsed as a `File <#File>`__
 
-[[PathList]] PathList ~~~~~~~~ Space-separated list of paths
+.. _PathList:
 
-Each element in the list is subjected to expansion of environment variables and
-   to home directories
+PathList
+--------
 
-[[SimulatorList]] SimulatorList ~~~~~~~~~~~~~ List of supported
-simulators. Allowed values are ghdl, icarus, isim, modelsim, verilator,
-xsim
+Space-separated list of paths
 
-[[SourceType]] SourceType ~~~~~~~~~~ Language used for Verilator
-testbenches. Allowed values are C, CPP or systemC
+Each element in the list is subjected to expansion of environment
+variables and ``~`` to home directories
 
-[[StringList]] StringList ~~~~~~~~~~ Space-separated list of strings
+.. _SimulatorList:
 
-[[VlnvList]] VlnvList ~~~~~~~~ Space-separated list of VLNV tags
+SimulatorList
+-------------
+
+List of supported simulators. Allowed values are ghdl, icarus, isim,
+modelsim, vcs, verilator, xsim
+
+.. _SourceType:
+
+SourceType
+----------
+
+Language used for Verilator testbenches. Allowed values are C, CPP or
+systemC
+
+.. _StringList:
+
+StringList
+----------
+
+Space-separated list of strings
+
+.. _VlnvList:
+
+VlnvList
+--------
+
+Space-separated list of VLNV tags
 
 Each element is treated as a VLNV element with an optional version range
 
-Example: librecores.org:peripherals:uart16550:1.5 >=::simple_spi:1.6
-mor1kx =::i2c:1.14
+Example:
 
-[[FileTypes]] File types ———-
+.. code-block ::
 
-The following valid file types are defined: PCF, QIP, SDC, UCF,
+   librecores.org:peripherals:uart16550:1.5 >=::simple_spi:1.6
+   mor1kx =::i2c:1.14``
+
+.. _FileTypes:
+
+File types
+==========
+
+The following valid file types are defined: PCF, QIP, SDC, UCF, BMM,
 tclSource, user, verilogSource, verilogSource-95, verilogSource-2001,
 verilogSource-2005, systemVerilogSource, systemVerilogSource-3.0,
 systemVerilogSource-3.1, systemVerilogSource-3.1a, vhdlSource,
 vhdlSource-87, vhdlSource-93, vhdlSource-2008, xci, xdc
 
+.. _sections:
+
 Sections
+========
+
+.. _fileset:
+
+fileset
+-------
+
+.. list-table::
+   :widths: 33 33 33
+   :header-rows: 0
+
+
+   * - Name
+     - Type
+     - Description
+
+   * - file_type
+     - String
+     - Default file type of the files in fileset
+
+   * - files
+     - `FileList <# FileList>`__
+     - List of files in fileset
+
+   * - is_include_file
+     - String
+     - Specify all files in fileset as include
+       files
+
+   * - logical_name
+     - String
+     - Default logical_name (e.g. library) of the
+       files in fileset
+
+   * - scope
+     - String
+     - Visibility of fileset (private/public).
+       Private filesets are only visible when
+       this core is the top-level. Public
+       filesets are visible also for cores that
+       depend on this core. Default is public
+
+   * - usage
+     - `StringList <#StringList>`__
+     - List of tags describing when this fileset
+       should be used. Can be general such as sim
+       or synth, or tool-specific such as
+       quartus, verilator, icarus. Defaults to
+       *sim synth*.
+
+
+.. _ghdl:
+
+ghdl
+----
+
+.. list-table::
+   :widths: 33 33 33
+   :header-rows: 0
+
+
+   * - Name
+     - Type
+     - Description
+
+   * - analyze_options
+     - `StringList <#StringList>`__
+     - Extra GHDL analyzer options
+
+   * - depend
+     - `VlnvList <#VlnvList>`__
+     - Tool-specific Dependencies
+
+   * - run_options
+     - `StringList <#StringList>`__
+     - Extra GHDL run options
+
+
+.. _icarus:
+
+icarus
+------
+
+.. list-table::
+   :widths: 33 33 33
+   :header-rows: 0
+
+
+   * - Name
+     - Type
+     - Description
+
+   * - depend
+     - `VlnvList <#VlnvList>`__
+     - Tool-specific Dependencies
+
+   * - iverilog_options
+     - `StringList <#StringList>`__
+     - Extra Icarus verilog compile options
+
+
+.. _icestorm:
+
+icestorm
 --------
 
-fileset ~~~~~~~
+.. list-table::
+   :widths: 33 33 33
+   :header-rows: 0
 
-[cols=“2,1,5”,options=“header”] \|============================== \|Name
-\| Type \| Description \|file_type \| String \| Default file type of the
-files in fileset \|files \| <<FileList,FileList>> \| List of files in
-fileset \|is_include_file \| String \| Specify all files in fileset as
-include files \|logical_name \| String \| Default logical_name
-(e.g. library) of the files in fileset \|scope \| String \| Visibility
-of fileset (private/public). Private filesets are only visible when this
-core is the top-level. Public filesets are visible also for cores that
-depend on this core. Default is public \|usage \|
-<<StringList,StringList>> \| List of tags describing when this fileset
-should be used. Can be general such as sim or synth, or tool-specific
-such as quartus, verilator, icarus. Defaults to ‘sim synth’.
-\|==============================
 
-ghdl ~~~~
+   * - Name
+     - Type
+     - Description
 
-[cols=“2,1,5”,options=“header”] \|============================== \|Name
-\| Type \| Description \|analyze_options \| <<StringList,StringList>> \|
-Extra GHDL analyzer options \|depend \| <<VlnvList,VlnvList>> \|
-Tool-specific Dependencies \|run_options \| <<StringList,StringList>> \|
-Extra GHDL run options \|==============================
+   * - arachne_pnr_options
+     - `StringList <#StringList>`__
+     - arachne-pnr options
 
-icarus ~~~~~~
+   * - depend
+     - `VlnvList <#VlnvList>`__
+     - Tool-specific Dependencies
 
-[cols=“2,1,5”,options=“header”] \|============================== \|Name
-\| Type \| Description \|depend \| <<VlnvList,VlnvList>> \|
-Tool-specific Dependencies \|iverilog_options \|
-<<StringList,StringList>> \| Extra Icarus verilog compile options
-\|==============================
+   * - pcf_file
+     - `FileList <#FileList>`__
+     - Physical constraint file
 
-icestorm ~~~~~~~~
+   * - top_module
+     - String
+     - RTL top-level module
 
-[cols=“2,1,5”,options=“header”] \|============================== \|Name
-\| Type \| Description \|arachne_pnr_options \|
-<<StringList,StringList>> \| arachne-pnr options \|depend \|
-<<VlnvList,VlnvList>> \| Tool-specific Dependencies \|pcf_file \|
-<<FileList,FileList>> \| Physical constraint file \|top_module \| String
-\| RTL top-level module \|yosys_synth_options \|
-<<StringList,StringList>> \| Additional options for the synth_\*
-commands in yosys \|==============================
+   * - yosys_synth_options
+     - `StringList <#StringList>`__
+     - Additional options for the ``synth_*`` commands in yosys
 
-ise ~~~
 
-[cols=“2,1,5”,options=“header”] \|============================== \|Name
-\| Type \| Description \|depend \| <<VlnvList,VlnvList>> \|
-Tool-specific Dependencies \|device \| String \| FPGA device identifier
-\|family \| String \| FPGA device family \|package \| String \| FPGA
-device package \|speed \| String \| FPGA device speed grade \|tcl_files
-\| <<FileList,FileList>> \| Extra TCL scripts \|top_module \| String \|
-RTL top-level module \|ucf_files \| <<FileList,FileList>> \| UCF
-constraint files \|==============================
+.. _ise:
 
-isim ~~~~
+ise
+---
 
-[cols=“2,1,5”,options=“header”] \|============================== \|Name
-\| Type \| Description \|depend \| <<VlnvList,VlnvList>> \|
-Tool-specific Dependencies \|isim_options \| <<StringList,StringList>>
-\| Extra Isim compile options \|==============================
+.. list-table::
+   :widths: 33 33 33
+   :header-rows: 0
 
-main ~~~~
 
-[cols=“2,1,5”,options=“header”] \|============================== \|Name
-\| Type \| Description \|backend \| String \| Backend for FPGA
-implementation \|component \| <<PathList,PathList>> \| Core IP-Xact
-component file \|depend \| <<VlnvList,VlnvList>> \| Common dependencies
-\|description \| String \| Core description \|name \| String \|
-Component name \|patches \| <<StringList,StringList>> \|
-FuseSoC-specific patches \|simulators \| <<SimulatorList,SimulatorList>>
-\| Supported simulators. Valid values are icarus, modelsim, verilator,
-isim and xsim. Each simulator have a dedicated section desribed
-elsewhere in this document \|==============================
+   * - Name
+     - Type
+     - Description
 
-modelsim ~~~~~~~~
+   * - depend
+     - `VlnvList <#VlnvList>`__
+     - Tool-specific Dependencies
 
-[cols=“2,1,5”,options=“header”] \|============================== \|Name
-\| Type \| Description \|depend \| <<VlnvList,VlnvList>> \|
-Tool-specific Dependencies \|vlog_options \| <<StringList,StringList>>
-\| Additional arguments for vlog \|vsim_options \|
-<<StringList,StringList>> \| Additional arguments for vsim
-\|==============================
+   * - device
+     - String
+     - FPGA device identifier
 
-parameter ~~~~~~~~~
+   * - family
+     - String
+     - FPGA device family
 
-[cols=“2,1,5”,options=“header”] \|============================== \|Name
-\| Type \| Description \|datatype \| String \| Data type of argument
-(int, str, bool, file \|default \| String \| Default value of argument
-\|description \| String \| Parameter description \|paramtype \| String
-\| Type of parameter (plusarg, vlogparam, generic, cmdlinearg \|scope \|
-String \| Visibility of parameter. Private parameters are only visible
-when this core is the top-level. Public parameters are visible also when
-this core is pulled in as a dependency of another core
-\|==============================
+   * - package
+     - String
+     - FPGA device package
 
-quartus ~~~~~~~
+   * - speed
+     - String
+     - FPGA device speed grade
 
-[cols=“2,1,5”,options=“header”] \|============================== \|Name
-\| Type \| Description \|depend \| <<VlnvList,VlnvList>> \|
-Tool-specific Dependencies \|device \| String \| FPGA device identifier
-\|family \| String \| FPGA device family \|qsys_files \|
-<<FileList,FileList>> \| Qsys IP description files \|quartus_options \|
-String \| Quartus command-line options \|sdc_files \|
-<<FileList,FileList>> \| SDC constraint files \|tcl_files \|
-<<FileList,FileList>> \| Extra script files \|top_module \| String \|
-RTL top-level module \|==============================
+   * - tcl_files
+     - `FileList <#FileList>`__
+     - Extra TCL scripts
 
-rivierapro ~~~~~~~~~~
+   * - top_module
+     - String
+     - RTL top-level module
 
-[cols=“2,1,5”,options=“header”] \|============================== \|Name
-\| Type \| Description \|depend \| <<VlnvList,VlnvList>> \|
-Tool-specific Dependencies \|vlog_options \| <<StringList,StringList>>
-\| Additional arguments for vlog \|vsim_options \|
-<<StringList,StringList>> \| Additional arguments for vsim
-\|==============================
+   * - ucf_files
+     - `FileList <#FileList>`__
+     - UCF constraint files
 
-scripts ~~~~~~~
 
-[cols=“2,1,5”,options=“header”] \|============================== \|Name
-\| Type \| Description \|post_impl_scripts \| <<StringList,StringList>>
-\| Scripts to run after backend implementation \|post_run_scripts \|
-<<StringList,StringList>> \| Scripts to run after simulations
-\|pre_build_scripts \| <<StringList,StringList>> \| Scripts to run
-before building \|pre_run_scripts \| <<StringList,StringList>> \|
-Scripts to run before running simulations \|pre_synth_scripts \|
-<<StringList,StringList>> \| Scripts to run before backend synthesis
-\|==============================
+.. _isim:
 
-verilator ~~~~~~~~~
+isim
+----
 
-[cols=“2,1,5”,options=“header”] \|============================== \|Name
-\| Type \| Description \|cli_parser \| String \| Select CLI argument
-parser. Set to ‘fusesoc’ to handle parameter sections like other
-simulators. Set to ‘passthrough’ to send the arguments directly to the
-verilated model. Default is ‘passthrough’ \|define_files \|
-<<PathList,PathList>> \| Verilog include files containing \`define
-directives to be converted to C #define directives in corresponding .h
-files (deprecated) \|depend \| <<VlnvList,VlnvList>> \| Tool-specific
-Dependencies \|include_files \| <<FileList,FileList>> \| Verilator
-testbench C include files \|libs \| <<PathList,PathList>> \| External
-libraries linked with the generated model \|source_type \| String \|
-Testbench source code language (Legal values are systemC, C, CPP.
-Default is C) \|src_files \| <<FileList,FileList>> \| Verilator
-testbench C/cpp/sysC source files \|tb_toplevel \| <<FileList,FileList>>
-\| Testbench top-level C/C++/SC file \|top_module \| String \| verilog
-top-level module \|verilator_options \| <<StringList,StringList>> \|
-Verilator build options \|==============================
+.. list-table::
+   :widths: 33 33 33
+   :header-rows: 0
 
-verilog ~~~~~~~
 
-[cols=“2,1,5”,options=“header”] \|============================== \|Name
-\| Type \| Description \|file_type \| String \| Default file type of the
-files in fileset \|include_files \| <<FileList,FileList>> \| Verilog
-include files \|src_files \| <<FileList,FileList>> \| Verilog source
-files for synthesis/simulation \|tb_include_files \|
-<<FileList,FileList>> \| Testbench include files \|tb_private_src_files
-\| <<FileList,FileList>> \| Verilog source files that are only used in
-the core’s own testbench. Not visible to other cores \|tb_src_files \|
-<<FileList,FileList>> \| Verilog source files that are only used in
-simulation. Visible to other cores \|==============================
+   * - Name
+     - Type
+     - Description
 
-vhdl ~~~~
+   * - depend
+     - `VlnvList <#VlnvList>`__
+     - Tool-specific Dependencies
 
-[cols=“2,1,5”,options=“header”] \|============================== \|Name
-\| Type \| Description \|src_files \| <<PathList,PathList>> \| VHDL
-source files for simulation and synthesis
-\|==============================
+   * - isim_options
+     - `StringList <#StringList>`__
+     - Extra Isim compile options
 
-vivado ~~~~~~
 
-[cols=“2,1,5”,options=“header”] \|============================== \|Name
-\| Type \| Description \|depend \| <<VlnvList,VlnvList>> \|
-Tool-specific Dependencies \|hw_device \| String \| FPGA device
-identifier \|part \| String \| FPGA device part \|top_module \| String
-\| RTL top-level module \|==============================
+.. _main:
 
-vpi ~~~
+main
+----
 
-[cols=“2,1,5”,options=“header”] \|============================== \|Name
-\| Type \| Description \|include_files \| <<FileList,FileList>> \| C
-include files for VPI library \|libs \| <<StringList,StringList>> \|
-External libraries linked with the VPI library \|src_files \|
-<<FileList,FileList>> \| C source files for VPI library
-\|==============================
+.. list-table::
+   :widths: 33 33 33
+   :header-rows: 0
 
-xsim ~~~~
 
-[cols=“2,1,5”,options=“header”] \|============================== \|Name
-\| Type \| Description \|depend \| <<VlnvList,VlnvList>> \|
-Tool-specific Dependencies \|xsim_options \| <<StringList,StringList>>
-\| Extra Xsim compile options \|==============================
+   * - Name
+     - Type
+     - Description
 
-provider ~~~~~~~~ The provider section gives information on where to
-find the source code for the core. If the provider section is missing,
-the core is assumed to be local, with the directory of the .core file as
-the root directory.
+   * - backend
+     - String
+     - Backend for FPGA implementation
 
-[cols=“2,1,5”,options=“header”] \|============================== \|Name
-\| Type \| Description \|name \| String \| The name option selects which
-provider backend to use. All other provider options are specific to the
-selected provider. Currently supported backends are github, git,
-opencores, submodule and url. \|cachable \| boolean \| If the cachable
-option is set to false, FuseSoc will unconditionally refetch the core
-even if it is found in the cache. Default is true
-\|==============================
+   * - component
+     - `PathL ist <# PathLi st>`__
+     - Core IP-Xact component file
+
+   * - depend
+     - `VlnvList <#VlnvList>`__
+     - Common dependencies
+
+   * - description
+     - String
+     - Core description
+
+   * - name
+     - String
+     - Component name
+
+   * - patches
+     - `StringList <#StringList>`__
+     - FuseSoC-specific patches
+
+   * - simulators
+     - `SimulatorList <#SimulatorList>`__
+     - Supported simulators. Valid values are
+       icarus, modelsim, verilator, isim and
+       xsim. Each simulator have a dedicated
+       section desribed elsewhere in this
+       document
+
+
+.. _modelsim:
+
+modelsim
+--------
+
+.. list-table::
+   :widths: 33 33 33
+   :header-rows: 0
+
+
+   * - Name
+     - Type
+     - Description
+
+   * - depend
+     - `VlnvList <#VlnvList>`__
+     - Tool-specific Dependencies
+
+   * - vlog_options
+     - `StringList <#StringList>`__
+     - Additional arguments for vlog
+
+   * - vsim_options
+     - `StringList <#StringList>`__
+     - Additional arguments for vsim
+
+
+.. _parameter:
+
+parameter
+---------
+
+.. list-table::
+   :widths: 33 33 33
+   :header-rows: 0
+
+
+   * - Name
+     - Type
+     - Description
+
+   * - datatype
+     - String
+     - Data type of argument (int, str, bool,
+       file
+
+   * - default
+     - String
+     - Default value of argument
+
+   * - description
+     - String
+     - Parameter description
+
+   * - paramtype
+     - String
+     - Type of parameter (plusarg, vlogparam,
+       generic, cmdlinearg
+
+   * - scope
+     - String
+     - Visibility of parameter. Private
+       parameters are only visible when this core
+       is the top-level. Public parameters are
+       visible also when this core is pulled in
+       as a dependency of another core
+
+
+.. _quartus:
+
+quartus
+-------
+
+.. list-table::
+   :widths: 33 33 33
+   :header-rows: 0
+
+
+   * - Name
+     - Type
+     - Description
+
+   * - depend
+     - `VlnvList <#VlnvList>`__
+     - Tool-specific Dependencies
+
+   * - device
+     - String
+     - FPGA device identifier
+
+   * - family
+     - String
+     - FPGA device family
+
+   * - qsys_files
+     - `FileList <#FileList>`__
+     - Qsys IP description files
+
+   * - quartus_options
+     - String
+     - Quartus command-line options
+
+   * - sdc_files
+     - `FileList <#FileList>`__
+     - SDC constraint files
+
+   * - tcl_files
+     - `FileList <#FileList>`__
+     - Extra script files
+
+   * - top_module
+     - String
+     - RTL top-level module
+
+
+.. _rivierapro:
+
+rivierapro
+----------
+
+.. list-table::
+   :widths: 33 33 33
+   :header-rows: 0
+
+
+   * - Name
+     - Type
+     - Description
+
+   * - depend
+     - `VlnvList <#VlnvList>`__
+     - Tool-specific Dependencies
+
+   * - vlog_options
+     - `StringList <#StringList>`__
+     - Additional arguments for vlog
+
+   * - vsim_options
+     - `StringList <#StringList>`__
+     - Additional arguments for vsim
+
+
+.. _scripts:
+
+scripts
+-------
+
+.. list-table::
+   :widths: 33 33 33
+   :header-rows: 0
+
+
+   * - Name
+     - Type
+     - Description
+
+   * - post_impl_scripts
+     - `StringList <#StringList>`__
+     - Scripts to run after backend
+       implementation
+
+   * - post_run_scripts
+     - `StringList <#StringList>`__
+     - Scripts to run after simulations
+
+   * - pre_build_scripts
+     - `StringList <#StringList>`__
+     - Scripts to run before building
+
+   * - pre_run_scripts
+     - `StringList <#StringList>`__
+     - Scripts to run before running simulations
+
+   * - pre_synth_scripts
+     - `StringList <#StringList>`__
+     - Scripts to run before backend synthesis
+
+
+.. _trellis:
+
+trellis
+-------
+
+.. list-table::
+   :widths: 33 33 33
+   :header-rows: 0
+
+
+   * - Name
+     - Type
+     - Description
+
+   * - depend
+     - `VlnvList <#VlnvList>`__
+     - Tool-specific Dependencies
+
+   * - nextpnr_options
+     - `StringList <#StringList>`__
+     - nextpnr options
+
+   * - top_module
+     - String
+     - RTL top-level module
+
+   * - yosys_synth_options
+     - `StringList <#StringList>`__
+     - Additional options for the ``synth_*`` commands in yosys
+
+
+.. _vcs:
+
+vcs
+---
+
+.. list-table::
+   :widths: 33 33 33
+   :header-rows: 0
+
+
+   * - Name
+     - Type
+     - Description
+
+   * - depend
+     - `VlnvList <#VlnvList>`__
+     - Tool-specific Dependencies
+
+   * - vcs_options
+     - `StringList <#StringList>`__
+     - Extra vcs compile options
+
+
+.. _verilator:
+
+verilator
+---------
+
+.. list-table::
+   :widths: 33 33 33
+   :header-rows: 0
+
+
+   * - Name
+     - Type
+     - Description
+
+   * - cli_parser
+     - String
+     - Select CLI argument parser. Set to
+       *fusesoc* to handle parameter sections
+       like other simulators. Set to
+       *passthrough* to send the arguments
+       directly to the verilated model. Default
+       is *passthrough*
+
+   * - define_files
+     - `PathL ist <# PathLi st>`__
+     - Verilog include files containing \`define
+       directives to be converted to C #define
+       directives in corresponding .h files
+       (deprecated)
+
+   * - depend
+     - `VlnvList <#VlnvList>`__
+     - Tool-specific Dependencies
+
+   * - include_files
+     - `FileList <#FileList>`__
+     - Verilator testbench C include files
+
+   * - libs
+     - `PathL ist <# PathLi st>`__
+     - External libraries linked with the
+       generated model
+
+   * - source_type
+     - String
+     - Testbench source code language (Legal
+       values are systemC, C, CPP. Default is C)
+
+   * - src_files
+     - `FileList <#FileList>`__
+     - Verilator testbench C/cpp/sysC source
+       files
+
+   * - tb_toplevel
+     - `FileList <#FileList>`__
+     - Testbench top-level C/C++/SC file
+
+   * - top_module
+     - String
+     - verilog top-level module
+
+   * - verilator_options
+     - `StringList <#StringList>`__
+     - Verilator build options
+
+
+.. _verilog:
+
+verilog
+-------
+
+.. list-table::
+   :widths: 33 33 33
+   :header-rows: 0
+
+
+   * - Name
+     - Type
+     - Description
+
+   * - file_type
+     - String
+     - Default file type of the files in fileset
+
+   * - include_files
+     - `FileList <#FileList>`__
+     - Verilog include files
+
+   * - src_files
+     - `FileList <#FileList>`__
+     - Verilog source files for
+       synthesis/simulation
+
+   * - tb_include_files
+     - `FileList <#FileList>`__
+     - Testbench include files
+
+   * - tb_private_src_files
+     - `FileList <#FileList>`__
+     - Verilog source files that are only used in
+       the core’s own testbench. Not visible to
+       other cores
+
+   * - tb_src_files
+     - `FileList <#FileList>`__
+     - Verilog source files that are only used in
+       simulation. Visible to other cores
+
+
+.. _vhdl:
+
+vhdl
+----
+
+.. list-table::
+   :widths: 33 33 33
+   :header-rows: 0
+
+
+   * - Name
+     - Type
+     - Description
+
+   * - src_files
+     - `PathL ist <# PathLi st>`__
+     - VHDL source files for simulation and
+       synthesis
+
+
+.. _vivado:
+
+vivado
+------
+
+.. list-table::
+   :widths: 33 33 33
+   :header-rows: 0
+
+
+   * - Name
+     - Type
+     - Description
+
+   * - depend
+     - `VlnvList <#VlnvList>`__
+     - Tool-specific Dependencies
+
+   * - hw_device
+     - String
+     - FPGA device identifier
+
+   * - part
+     - String
+     - FPGA device part
+
+   * - top_module
+     - String
+     - RTL top-level module
+
+
+.. _vpi:
+
+vpi
+---
+
+.. list-table::
+   :widths: 33 33 33
+   :header-rows: 0
+
+
+   * - Name
+     - Type
+     - Description
+
+   * - include_files
+     - `FileList <#FileList>`__
+     - C include files for VPI library
+
+   * - libs
+     - `StringList <#StringList>`__
+     - External libraries linked with the VPI
+       library
+
+   * - src_files
+     - `FileList <#FileList>`__
+     - C source files for VPI library
+
+
+.. _xsim:
+
+xsim
+----
+
+.. list-table::
+   :widths: 33 33 33
+   :header-rows: 0
+
+
+   * - Name
+     - Type
+     - Description
+
+   * - depend
+     - `VlnvList <#VlnvList>`__
+     - Tool-specific Dependencies
+
+   * - xsim_options
+     - `StringList <#StringList>`__
+     - Extra Xsim compile options
+
+
+.. _provider:
+
+provider
+--------
+
+The provider section gives information on where to find the source code
+for the core. If the provider section is missing, the core is assumed to
+be local, with the directory of the .core file as the root directory.
+
+.. list-table::
+   :widths: 33 33 33
+   :header-rows: 0
+
+
+   * - Name
+     - Type
+     - Description
+
+   * - name
+     - String
+     - The name option selects which provider
+       backend to use. All other provider options
+       are specific to the selected provider.
+       Currently supported backends are github,
+       git, opencores, submodule and url.
+
+   * - cachable
+     - boolean
+     - If the cachable option is set to false,
+       FuseSoc will unconditionally refetch the
+       core even if it is found in the cache.
+       Default is true
+
 
 Provider-specific options:
 
-github ^^^^^^ \* *user :* Name of the github user or organisation.
+.. _github:
 
--  *repo :* Name of the GIT repository.
+github
+~~~~~~
 
--  *version :* Name of the GIT ref (i.e. commit SHA, branch or tag) to
+-  **user :** Name of the github user or organisation.
+
+-  **repo :** Name of the GIT repository.
+
+-  **version :** Name of the GIT ref (i.e. commit SHA, branch or tag) to use
+
+.. _git:
+
+git
+~~~
+
+-  **repo :** URL of the GIT repository.
+
+-  **version :** Name of the GIT ref (i.e. commit SHA, branch or tag) to
    use
 
-git ^^^ \* *repo :* URL of the GIT repository.
+.. _opencores:
 
--  *version :* Name of the GIT ref (i.e. commit SHA, branch or tag) to
-   use
+opencores
+~~~~~~~~~
 
-opencores ^^^^^^^^^ \* *repo_name :* Name of the opencores project. Can
-be found under Details on the project homepage.
+-  **repo_name :** Name of the opencores project. Can be found under
+   Details on the project homepage.
 
--  *repo_root :* The sub directory in the repo that contains the files
-   of interest. In most cases the value “trunk” is used to avoid pulling
+-  **repo_root :** The sub directory in the repo that contains the files
+   of interest. In most cases the value "trunk" is used to avoid pulling
    in tags and branches.
 
--  *revision :* The svn revision of the repository.
+-  **revision :** The svn revision of the repository.
 
-url ^^^ \* *url :* URL of the core file (or archive).
+.. _url:
 
--  *filetype :* File type (zip, tar, simple).
+url
+~~~
+
+-  **url :** URL of the core file (or archive).
+
+-  **filetype :** File type (zip, tar, simple).
+
+.. _known_issues:
 
 Known issues
-------------
+============
 
-. The configparser in python 2 doesn’t handle spaces before values in
-multiline options. + .Illegal comment style ————– src_files = clkgen.v
-#gpio.v fusesoc_top.v ————– + This is not legal in python 2, while: +
-.Legal comment style ————– src_files = clkgen.v # gpio.v fusesoc_top.v
-————– + is ok in python 2 and python 3. + . Spaces are not allowed
-anywhere in the paths.
+1. Spaces are not allowed anywhere in the paths.

--- a/doc/source/ref/migrations.rst
+++ b/doc/source/ref/migrations.rst
@@ -1,13 +1,15 @@
+***************
 Migration guide
-===============
+***************
 
-FuseSoC strives to be backwards-compatible, but as new features are added to FuseSoC, some older features become obsolete. This chapter contains information on how to migrate away from deprecated features to keep the core description files up-to-date with the latest best practices.
+FuseSoC strives to be backwards-compatible, but as new features are added to FuseSoC, some older features become obsolete.
+This chapter contains information on how to migrate away from deprecated features to keep the core description files up-to-date with the latest best practices.
 
 Migrating from .system files
-----------------------------
+============================
 
 Why
-~~~
+---
 
 The synthesis backends required a separate .system file in addition to
 the .core file. There is however very little information in the .system
@@ -17,7 +19,7 @@ drop the .system file and move the relevant information to the .core
 file instead.
 
 When
-~~~~
+----
 
 ``.system`` files are no longer needed as of FuseSoC 1.6
 
@@ -26,7 +28,7 @@ users to perform the migration, but any equivalent options in the
 ``.core`` file will override the ones in ``.system``
 
 How
-~~~
+---
 
 Perform the following steps to migrate from .system files
 
@@ -45,10 +47,10 @@ Perform the following steps to migrate from .system files
    in the ``.core`` file.
 
 Migrating from plusargs
------------------------
+=======================
 
 Why
-~~~
+---
 
 Up until FuseSoC 1.3, verilog plusargs were the only way to set
 external run-time parameters. Cores could register which plusargs they
@@ -58,14 +60,14 @@ defines, VHDL generics etc, ``parameter`` sections were introduced to
 replace the ``plusargs`` section.
 
 When
-~~~~
+----
 
 ``parameter`` sections were introduced in FuseSoC 1.3
 
 The ``plusargs`` section is still supported to allow time for migrations
 
 How
-~~~
+---
 
 Entries in the ``plusargs`` section are described as
 ``<name> = <type> <description>``. For each of these entries, create a
@@ -84,10 +86,10 @@ be visible to other cores (``scope=public``) or only when this core is
 used as the toplevel (``scope=private``).
 
 Migrating to filesets
----------------------
+=====================
 
 Why
-~~~
+---
 
 Originally only verilog source files were supported. In order to
 make source code handling more generic, filesets were introduced.
@@ -98,14 +100,14 @@ files. The verilog section is still supported for some time to allow
 users to perform the migration.
 
 When
-~~~~
+----
 
 ``fileset`` sections were introduced in FuseSoC 1.4
 
 The ``verilog`` section is still supported to allow time for migrations
 
 How
-~~~
+---
 
 Given a ``verilog`` section with the following contents:
 
@@ -181,10 +183,10 @@ attributes
 and usage are set for each fileset.
 
 Migrating from verilator define_files
--------------------------------------
+=====================================
 
 Why
-~~~
+---
 
 Files specified as ``define_files`` in the verilator core
 section were treated as verilog files containing ```define``
@@ -195,12 +197,12 @@ FuseSoC code base. The decision is therefore made to deprecate this
 functionality and instead require the user to make the conversion.
 
 When
-~~~~
+----
 
 ``verilator define_files`` are no longer converted in FuseSoC 1.7
 
 How
-~~~
+---
 
 The following stand-alone Python script will perform the same function.
 It can also be executed as a ``pre_build`` script to perform the
@@ -227,10 +229,10 @@ conversion automatically before a build
        convert_V2H(sys.argv[1], sys.argv[2])
 
 Redefining build_root
----------------------
+=====================
 
 Why
-~~~
+---
 As an aid for scripts executed during the build process, a number of environment variables were defined. Unfortunately this was done without too much thought and as time moved on, some of these turned out to be a maintenance burden without bringing much benefit, and in some cases without ever being used.
 
 At the same time, the introduction of VLNV and dependency ranges has introduced non-determinism in where the output of a build ends up. For these reasons, it was determined to redefine the rarely used `build_root` variable to point to the the directory containing the work root and exported files. A `--build-root` command-line switch is introduced to explictly set a build_root. Setting `build_root` in `fusesoc.conf` will keep working the same way as before, but the command-line switch takes precedence. CAPI1 cores will no longer export the `BUILD_ROOT` environment variable.
@@ -240,9 +242,9 @@ These changes affects the following cases:
 * Relying on the `BUILD_ROOT` variable in scripts called from CAPI1 cores.
 
 When
-~~~~
+----
 `build_root` was redefined after the release of FuseSoC 1.9.1
 
 How
-~~~
-Any scripts that previously relied on `$BUILD_ROOT` will have to be updated. Note that due to other changes in FuseSoC most of them were unlikely to work at this point anyway.
+---
+Any scripts that previously relied on ``$BUILD_ROOT`` will have to be updated. Note that due to other changes in FuseSoC most of them were unlikely to work at this point anyway.


### PR DESCRIPTION
The content is still outdated, but at least it now renders.