### PR TITLE
Issue deprecation warning for CAPI1

### DIFF
--- a/fusesoc/core.py
+++ b/fusesoc/core.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: BSD-2-Clause
 
 import logging
+import warnings
 
 from fusesoc.capi1.core import Core as Capi1Core
 from fusesoc.capi2.core import Core as Capi2Core
@@ -20,6 +21,12 @@ class Core:
             else:
                 first_line = ""
             if first_line == "CAPI=1":
+                warnings.warn(
+                    "The CAPI1 core file description format is deprecated and "
+                    "will be removed in the next major version of FuseSoC. "
+                    "Please port your core files to the CAPI2 format.",
+                    FutureWarning,
+                )
                 return Capi1Core(*args, **kwargs)
             elif first_line == "CAPI=2:":
                 return Capi2Core(*args, **kwargs)

--- a/tests/test_capi1.py
+++ b/tests/test_capi1.py
@@ -27,6 +27,18 @@ def test_core_info():
             assert f.read() == gen_info, core_name
 
 
+def test_capi1_deprecation_warning():
+    from fusesoc.vlnv import Vlnv
+
+    tests_dir = os.path.dirname(__file__)
+    cores_root = os.path.join(tests_dir, "cores")
+    sockit_core = os.path.join(cores_root, "sockit", "sockit.core")
+
+    with pytest.warns(FutureWarning, match="is deprecated"):
+        core = Core(sockit_core)
+        assert core.name == Vlnv("::sockit:1.0")
+
+
 def test_core_parsing():
     from fusesoc.vlnv import Vlnv
 


### PR DESCRIPTION
The CAPI1 core description format has been deprecated for a while in our
documentation, but users of FuseSoC didn't, up to now, get a deprecation
warning when running `fusesoc`. Add such a warning to encourage users to
switch to CAPI2.

Commit deprecating CAPI1 in our docs: c03b095cf7d40e00d476ba5507c8e60a22286459 (Feb 2019)

Related to #361