### PR TITLE
Require Python 3.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,6 @@ jobs:
           - macos-latest
           - windows-latest
         python-version:
-          - 3.5
           - 3.6
           - 3.7
           - 3.8

--- a/doc/source/user/installation.rst
+++ b/doc/source/user/installation.rst
@@ -12,7 +12,7 @@ System Requirements
 Before installing FuseSoC check your system requirements.
 
 - Operating System: Linux, Windows, macOS
-- Python 3.5 or newer.
+- Python 3.6 or newer.
   (The last version supporting Python 2.7 is FuseSoC 1.10.)
 - The Python packages ``setuptools`` and ``pip`` need to be installed for Python 3.
 

--- a/setup.py
+++ b/setup.py
@@ -56,6 +56,6 @@ setup(
         "pyyaml",
         "simplesat>=0.8.0",
     ],
-    # Supported Python versions: 3.5+
-    python_requires=">=3.5, <4",
+    # Supported Python versions: 3.6+
+    python_requires=">=3.6, <4",
 )

--- a/tox.ini
+++ b/tox.ini
@@ -50,7 +50,6 @@ commands =
 # (see the pipeline configuration) due to
 # https://github.com/ymyzk/tox-gh-actions/issues/44.
 python =
-    3.5: py3-ci
     3.6: py3-ci
     3.7: py3-ci
     3.8: py3-ci


### PR DESCRIPTION
Python 3.5 is EOL upstream; remove support for it from FuseSoC to enable
us to use newer features.

Fixes #454