### PR TITLE
Use isort to sort all includes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,13 +18,18 @@ repos:
       - id: trailing-whitespace
         # Test golden references
         exclude: ^tests/(.+\.(info|patch)|test_provider/.+\.v)
-  - repo: https://github.com/psf/black
-    rev: 20.8b1
-    hooks:
-      - id: black
   - repo: https://github.com/asottile/pyupgrade
     rev: v2.7.4
     hooks:
       - id: pyupgrade
         # for now don't force to change from %-operator to {}
         args: [--keep-percent-format, --py3-plus]
+  - repo: https://github.com/PyCQA/isort
+    rev: "5.7.0"
+    hooks:
+      - id: isort
+        args: ["--profile", "black", "--filter-files"]
+  - repo: https://github.com/psf/black
+    rev: 20.8b1
+    hooks:
+      - id: black

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,30 +1,30 @@
 # Configuration for pre-commit (https://pre-commit.com/), a tool to run
 # formatters, linters, and other productivity tools before a commit.
 repos:
-- repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v3.3.0
-  hooks:
-  - id: check-ast
-  - id: check-builtin-literals
-  - id: check-case-conflict
-  - id: check-docstring-first
-  - id: requirements-txt-fixer
-  - id: check-yaml
-    types: [file]
-    files: ^tests/capi2_cores/.+\.core$
-  - id: end-of-file-fixer
-    # Test golden references
-    exclude: ^tests/(.+\.(info|patch)|test_provider/.+\.v)
-  - id: trailing-whitespace
-    # Test golden references
-    exclude: ^tests/(.+\.(info|patch)|test_provider/.+\.v)
-- repo: https://github.com/psf/black
-  rev: 20.8b1
-  hooks:
-  - id: black
-- repo: https://github.com/asottile/pyupgrade
-  rev: v2.7.4
-  hooks:
-  - id: pyupgrade
-    # for now don't force to change from %-operator to {}
-    args: [--keep-percent-format, --py3-plus]
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v3.3.0
+    hooks:
+      - id: check-ast
+      - id: check-builtin-literals
+      - id: check-case-conflict
+      - id: check-docstring-first
+      - id: requirements-txt-fixer
+      - id: check-yaml
+        types: [file]
+        files: ^tests/capi2_cores/.+\.core$
+      - id: end-of-file-fixer
+        # Test golden references
+        exclude: ^tests/(.+\.(info|patch)|test_provider/.+\.v)
+      - id: trailing-whitespace
+        # Test golden references
+        exclude: ^tests/(.+\.(info|patch)|test_provider/.+\.v)
+  - repo: https://github.com/psf/black
+    rev: 20.8b1
+    hooks:
+      - id: black
+  - repo: https://github.com/asottile/pyupgrade
+    rev: v2.7.4
+    hooks:
+      - id: pyupgrade
+        # for now don't force to change from %-operator to {}
+        args: [--keep-percent-format, --py3-plus]

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,6 +1,6 @@
 # Python requirements needed to develop fusesoc
 # "End-user" dependencies (during build or install time) are listed in setup.py
-pre-commit
+pre-commit>=2.9.0
 pytest>=3.3.0
 Sphinx
 sphinx_rtd_theme

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -9,12 +9,13 @@
 # full list see the documentation:
 # http://www.sphinx-doc.org/en/master/config
 
-import fusesoc
-from fusesoc.capi2.capi2 import gen_doc
-from datetime import datetime
-from distutils.version import LooseVersion
 import os
 import sys
+from datetime import datetime
+from distutils.version import LooseVersion
+
+import fusesoc
+from fusesoc.capi2.capi2 import gen_doc
 
 # -- Path setup --------------------------------------------------------------
 

--- a/fusesoc/capi1/core.py
+++ b/fusesoc/capi1/core.py
@@ -2,19 +2,20 @@
 # Licensed under the 2-Clause BSD License, see LICENSE for details.
 # SPDX-License-Identifier: BSD-2-Clause
 
-from collections import OrderedDict
 import importlib
 import logging
 import os
 import shutil
+from collections import OrderedDict
 
 from ipyxact.ipyxact import Component
+
 from fusesoc import utils
-from fusesoc.provider import get_provider
-from fusesoc.vlnv import Vlnv
 from fusesoc.capi1 import section
 from fusesoc.capi1.fusesocconfigparser import FusesocConfigParser
 from fusesoc.capi1.plusargs import Plusargs
+from fusesoc.provider import get_provider
+from fusesoc.vlnv import Vlnv
 
 logger = logging.getLogger(__name__)
 

--- a/fusesoc/capi1/section.py
+++ b/fusesoc/capi1/section.py
@@ -2,8 +2,9 @@
 # Licensed under the 2-Clause BSD License, see LICENSE for details.
 # SPDX-License-Identifier: BSD-2-Clause
 
-import os
 import logging
+import os
+
 from fusesoc.utils import unique_dirs
 from fusesoc.vlnv import Vlnv
 

--- a/fusesoc/capi2/core.py
+++ b/fusesoc/capi2/core.py
@@ -7,16 +7,14 @@ import logging
 import os
 import shutil
 import warnings
+
 import yaml
-
-from fusesoc import utils
-from fusesoc.provider import get_provider
-from fusesoc.vlnv import Vlnv
-
-from fusesoc.capi2.exprs import Exprs
-
 from edalize import get_edatools
 
+from fusesoc import utils
+from fusesoc.capi2.exprs import Exprs
+from fusesoc.provider import get_provider
+from fusesoc.vlnv import Vlnv
 
 logger = logging.getLogger(__name__)
 

--- a/fusesoc/capi2/exprs.py
+++ b/fusesoc/capi2/exprs.py
@@ -31,13 +31,13 @@ containing each word that matched.
 
 from pyparsing import (
     Forward,
+    Group,
     OneOrMore,
     Optional,
+    ParseException,
     Suppress,
     Word,
     alphanums,
-    Group,
-    ParseException,
 )
 
 

--- a/fusesoc/config.py
+++ b/fusesoc/config.py
@@ -2,16 +2,13 @@
 # Licensed under the 2-Clause BSD License, see LICENSE for details.
 # SPDX-License-Identifier: BSD-2-Clause
 
-from collections import OrderedDict
-import logging
-
-import sys
-
 import configparser
-from configparser import ConfigParser as CP
-
-import os
 import importlib
+import logging
+import os
+import sys
+from collections import OrderedDict
+from configparser import ConfigParser as CP
 
 from fusesoc.librarymanager import Library
 

--- a/fusesoc/core.py
+++ b/fusesoc/core.py
@@ -7,7 +7,6 @@ import logging
 from fusesoc.capi1.core import Core as Capi1Core
 from fusesoc.capi2.core import Core as Capi2Core
 
-
 logger = logging.getLogger(__name__)
 
 

--- a/fusesoc/coreconverter.py
+++ b/fusesoc/coreconverter.py
@@ -42,8 +42,10 @@
 
 import logging
 import os
-import yaml
 import sys
+
+import yaml
+
 from fusesoc.capi1.core import Core as Capi1Core
 from fusesoc.vlnv import Vlnv
 

--- a/fusesoc/coremanager.py
+++ b/fusesoc/coremanager.py
@@ -6,7 +6,6 @@ import logging
 import os
 
 from okonomiyaki.versions import EnpkgVersion
-
 from simplesat.constraints import PrettyPackageStringParser, Requirement
 from simplesat.dependency_solver import DependencySolver
 from simplesat.errors import NoPackageFound, SatisfiabilityError

--- a/fusesoc/edalizer.py
+++ b/fusesoc/edalizer.py
@@ -8,9 +8,9 @@ import os
 import shutil
 
 from fusesoc import utils
-from fusesoc.vlnv import Vlnv
-from fusesoc.utils import merge_dict
 from fusesoc.coremanager import DependencyError
+from fusesoc.utils import merge_dict
+from fusesoc.vlnv import Vlnv
 
 logger = logging.getLogger(__name__)
 

--- a/fusesoc/main.py
+++ b/fusesoc/main.py
@@ -5,9 +5,9 @@
 
 import argparse
 import os
+import signal
 import subprocess
 import sys
-import signal
 import warnings
 
 from fusesoc import __version__
@@ -19,16 +19,17 @@ fusesocdir = os.path.abspath(
 if os.path.exists(os.path.join(fusesocdir, "fusesoc")):
     sys.path[0:0] = [fusesocdir]
 
+import logging
+
+from edalize import get_edatool
+
 from fusesoc.config import Config
 from fusesoc.coreconverter import convert_core
 from fusesoc.coremanager import CoreManager, DependencyError
-from fusesoc.librarymanager import Library
 from fusesoc.edalizer import Edalizer
-from edalize import get_edatool
-from fusesoc.vlnv import Vlnv
+from fusesoc.librarymanager import Library
 from fusesoc.utils import Launcher, setup_logging, yaml_fread
-
-import logging
+from fusesoc.vlnv import Vlnv
 
 logger = logging.getLogger(__name__)
 

--- a/fusesoc/provider/coregen.py
+++ b/fusesoc/provider/coregen.py
@@ -5,6 +5,7 @@
 import logging
 import os
 import shutil
+
 from fusesoc.provider.provider import Provider
 from fusesoc.utils import Launcher
 

--- a/fusesoc/provider/git.py
+++ b/fusesoc/provider/git.py
@@ -3,9 +3,10 @@
 # SPDX-License-Identifier: BSD-2-Clause
 
 import logging
-import shutil
 import os.path
+import shutil
 import subprocess
+
 from fusesoc.provider.provider import Provider
 from fusesoc.utils import Launcher
 

--- a/fusesoc/provider/github.py
+++ b/fusesoc/provider/github.py
@@ -6,6 +6,7 @@ import logging
 import os.path
 import sys
 import tarfile
+
 from fusesoc.provider.provider import Provider
 
 logger = logging.getLogger(__name__)
@@ -15,6 +16,7 @@ if sys.version_info[0] >= 3:
     from urllib.error import URLError
 else:
     import urllib
+
     from urllib2 import URLError
 
 URL = "https://github.com/{user}/{repo}/archive/{version}.tar.gz"

--- a/fusesoc/provider/local.py
+++ b/fusesoc/provider/local.py
@@ -4,6 +4,7 @@
 
 import logging
 import os.path
+
 from fusesoc.provider.provider import Provider
 
 logger = logging.getLogger(__name__)

--- a/fusesoc/provider/logicore.py
+++ b/fusesoc/provider/logicore.py
@@ -5,6 +5,7 @@
 import logging
 import os
 import shutil
+
 from fusesoc.provider.provider import Provider
 from fusesoc.utils import Launcher
 

--- a/fusesoc/provider/provider.py
+++ b/fusesoc/provider/provider.py
@@ -5,6 +5,7 @@
 import logging
 import os
 import shutil
+
 from fusesoc.utils import Launcher
 
 logger = logging.getLogger(__name__)

--- a/fusesoc/provider/url.py
+++ b/fusesoc/provider/url.py
@@ -4,17 +4,16 @@
 
 import logging
 import os.path
+import shutil
 import sys
 import tarfile
 import zipfile
-import shutil
 
 logger = logging.getLogger(__name__)
 
 if sys.version_info[0] >= 3:
     import urllib.request as urllib
-    from urllib.error import URLError
-    from urllib.error import HTTPError
+    from urllib.error import HTTPError, URLError
 else:
     import urllib
     from urllib2 import URLError

--- a/fusesoc/utils.py
+++ b/fusesoc/utils.py
@@ -2,18 +2,20 @@
 # Licensed under the 2-Clause BSD License, see LICENSE for details.
 # SPDX-License-Identifier: BSD-2-Clause
 
-import subprocess
-import logging
-import sys
 import importlib
+import logging
+import subprocess
+import sys
 import warnings
 
 import yaml
 
 try:
-    from yaml import CSafeLoader as YamlLoader, CSafeDumper as YamlDumper
+    from yaml import CSafeDumper as YamlDumper
+    from yaml import CSafeLoader as YamlLoader
 except ImportError:
-    from yaml import SafeLoader as YamlLoader, SafeDumper as YamlDumper
+    from yaml import SafeDumper as YamlDumper
+    from yaml import SafeLoader as YamlLoader
 
 if sys.version[0] == "2":
     FileNotFoundError = OSError

--- a/fusesoc/vlnv.py
+++ b/fusesoc/vlnv.py
@@ -2,8 +2,8 @@
 # Licensed under the 2-Clause BSD License, see LICENSE for details.
 # SPDX-License-Identifier: BSD-2-Clause
 
-from functools import total_ordering
 import copy
+from functools import total_ordering
 
 
 @total_ordering

--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: BSD-2-Clause
 
 import os
+
 from setuptools import setup
 
 

--- a/tests/capi2_cores/misc/generate/testgen.py
+++ b/tests/capi2_cores/misc/generate/testgen.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: BSD-2-Clause
 
 import sys
+
 import yaml
 
 template = """CAPI=2:

--- a/tests/test_capi1.py
+++ b/tests/test_capi1.py
@@ -4,6 +4,7 @@
 
 import difflib
 import os
+
 import pytest
 
 from fusesoc.core import Core

--- a/tests/test_capi2.py
+++ b/tests/test_capi2.py
@@ -2,8 +2,9 @@
 # Licensed under the 2-Clause BSD License, see LICENSE for details.
 # SPDX-License-Identifier: BSD-2-Clause
 
-import pytest
 import os.path
+
+import pytest
 
 tests_dir = os.path.dirname(__file__)
 cores_dir = os.path.join(tests_dir, "capi2_cores", "misc")
@@ -12,6 +13,7 @@ cores_dir = os.path.join(tests_dir, "capi2_cores", "misc")
 def test_files_out_of_hierarchy():
     import os
     import tempfile
+
     from fusesoc.core import Core
 
     core_file = os.path.join(
@@ -35,6 +37,7 @@ def test_files_out_of_hierarchy():
 def test_empty_core():
     import os
     import tempfile
+
     from fusesoc.core import Core
 
     core_file = os.path.join(tests_dir, "capi2_cores", "misc", "empty.core")
@@ -46,6 +49,7 @@ def test_empty_core():
 def test_capi2_export():
     import os
     import tempfile
+
     from fusesoc.core import Core
 
     core_file = os.path.join(tests_dir, "capi2_cores", "misc", "files.core")
@@ -205,8 +209,8 @@ def test_capi2_get_generators():
 
 
 def test_capi2_get_parameters():
-    from fusesoc.core import Core
     from fusesoc.capi2.core import Generators
+    from fusesoc.core import Core
 
     core_file = os.path.join(tests_dir, "capi2_cores", "misc", "parameters.core")
     core = Core(core_file)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -2,12 +2,12 @@
 # Licensed under the 2-Clause BSD License, see LICENSE for details.
 # SPDX-License-Identifier: BSD-2-Clause
 
-import tempfile
 import os.path
+import tempfile
+
+from test_common import cache_root, cores_root, library_root
 
 from fusesoc.config import Config
-
-from test_common import cores_root, cache_root, library_root
 
 build_root = "test_build_root"
 

--- a/tests/test_coreconverter.py
+++ b/tests/test_coreconverter.py
@@ -1,7 +1,8 @@
 # TODO: probably https://gitlab.com/Rtzq0/structurediff should be used
 
-import pytest
 import os.path
+
+import pytest
 
 tests_dir = os.path.dirname(__file__)
 capi1_dir = os.path.join(tests_dir, "test_coreconverter", "capi1")
@@ -11,6 +12,7 @@ output_dir = os.path.join(tests_dir, "test_coreconverter", "capi2_converted")
 
 def test_coreconverter():
     import filecmp
+
     from fusesoc.coreconverter import convert_core
 
     for filename in os.listdir(capi1_dir):

--- a/tests/test_coremanager.py
+++ b/tests/test_coremanager.py
@@ -7,11 +7,12 @@ import pytest
 
 def test_deptree(tmp_path):
     import os
-    from fusesoc.coremanager import CoreManager
+
     from fusesoc.config import Config
+    from fusesoc.coremanager import CoreManager
+    from fusesoc.edalizer import Edalizer
     from fusesoc.librarymanager import Library
     from fusesoc.vlnv import Vlnv
-    from fusesoc.edalizer import Edalizer
 
     flags = {"tool": "icarus"}
 

--- a/tests/test_exprs.py
+++ b/tests/test_exprs.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: BSD-2-Clause
 
 import pytest
+
 from fusesoc.capi2.exprs import Exprs
 
 

--- a/tests/test_libraries.py
+++ b/tests/test_libraries.py
@@ -2,17 +2,16 @@
 # Licensed under the 2-Clause BSD License, see LICENSE for details.
 # SPDX-License-Identifier: BSD-2-Clause
 
-import tempfile
-import shutil
-import os.path
 import logging
+import os.path
+import shutil
 import subprocess
-
+import tempfile
 from argparse import Namespace
 
-from fusesoc.config import Config
+from test_common import cache_root, cores_root, library_root
 
-from test_common import cores_root, cache_root, library_root
+from fusesoc.config import Config
 
 build_root = "test_build_root"
 
@@ -58,9 +57,10 @@ def test_library_location():
 
 def test_library_add(caplog):
     import tempfile
-    from fusesoc.main import add_library
+
     from fusesoc.coremanager import CoreManager
     from fusesoc.librarymanager import LibraryManager
+    from fusesoc.main import add_library
 
     tcf = tempfile.NamedTemporaryFile(mode="w+")
     clone_target = tempfile.mkdtemp(prefix="library_add_")
@@ -131,7 +131,7 @@ auto-sync = true"""
 
 
 def test_library_update(caplog):
-    from fusesoc.main import update, init_coremanager, init_logging
+    from fusesoc.main import init_coremanager, init_logging, update
 
     clone_target = tempfile.mkdtemp()
 

--- a/tests/test_provider.py
+++ b/tests/test_provider.py
@@ -3,13 +3,13 @@
 # SPDX-License-Identifier: BSD-2-Clause
 
 import os
-import pytest
 import shutil
 import tempfile
 
-from fusesoc.core import Core
-
+import pytest
 from test_common import tests_dir
+
+from fusesoc.core import Core
 
 cores_root = os.path.join(tests_dir, "cores")
 


### PR DESCRIPTION
Isort enforces a single way to have includes sorted, which makes them slightly easier to read, but more importantly, removes the need to even think about it or do any formatting manually.