### PR TITLE
Show actual version output for documented version

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,2 +1,3 @@
 Sphinx >= 3.0
 sphinx-rtd-theme
+sphinxcontrib-programoutput

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -55,6 +55,7 @@ extensions = [
     "sphinx.ext.githubpages",
     "sphinx.ext.intersphinx",
     "sphinx.ext.todo",
+    "sphinxcontrib.programoutput",
 ]
 
 intersphinx_mapping = {"https://docs.python.org/3": None}

--- a/doc/source/user/installation.rst
+++ b/doc/source/user/installation.rst
@@ -45,10 +45,8 @@ If an older version of FuseSoC is found, this version is upgraded to the latest 
 
 Check that the installation worked by running
 
-.. code-block:: shell-session
+.. command-output:: fusesoc --version
 
-   $ fusesoc --version
-   1.9.3
 
 If this command works FuseSoC is installed properly and ready to be used.
 


### PR DESCRIPTION
When building the documentation we now execute `fusesoc --version` to
ensure that the documentation gives exactly the same output as the user
is expected to get, as long as they are reading the documentation
matching their installed version.

As a slight downside, we loose syntax highlighting for that block,
making it inconsistent with the other command snippets on the page. It's
fixable, but didn't seem worth it for now.