### PR TITLE
Ignore reformatting commit in git blame

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# Ignore reformatting changes in git blame.
+3bd574aa7aa8330785a4362fde249dae7d7b6562


### PR DESCRIPTION
When using `git blame`, ignore commits which are only reformatting the
source code. This makes it easier to see who actually changed the line
functionally, instead of always referring to commits which reformatted
the whole source code.