### PR TITLE
Add a editorconfig file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,19 @@
+# Editorconfig, a commonly used configuration file for editors.
+# See https://editorconfig.org/ for details and syntax.
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+end_of_line = lf
+insert_final_newline = true
+charset = utf-8
+
+# 4 space indentation
+[*.py]
+indent_style = space
+indent_size = 4
+trim_trailing_whitespace = true
+
+# Tab indentation (no size specified)
+[Makefile]
+indent_style = tab


### PR DESCRIPTION
To quote editorconfig.org:

"EditorConfig helps maintain consistent coding styles for multiple
developers working on the same project across various editors and IDEs.
The EditorConfig project consists of a file format for defining coding
styles and a collection of text editor plugins that enable editors to
read the file format and adhere to defined styles. EditorConfig files
are easily readable and they work nicely with version control systems."

This commit adds a very basic editorconfig file to catch the most common
cases.