### PR TITLE
Remove variable expansion from generate names

### DIFF
--- a/fusesoc/capi2/core.py
+++ b/fusesoc/capi2/core.py
@@ -80,9 +80,9 @@ class StringWithUseFlagsOrDict:
         if type(tree) is dict:
             for k, v in tree.items():
                 self.params = v
-                self.name = StringWithUseFlags(os.path.expandvars(k))
+                self.name = StringWithUseFlags(k)
         else:
-            self.name = StringWithUseFlags(os.path.expandvars(tree))
+            self.name = StringWithUseFlags(tree)
 
 
 class Section:


### PR DESCRIPTION
The current code expands environment variables in
`targets.*.generate` blocks. This behavior is not documented and was
likely introduced in error in commit 4d02c089. Since we haven't released
this feature yet, let's remove it.

Example: before this patch, the following was possible, assuming
`TESTGEN_ENV_VAR` was set to `testgen`.

```
name : ::expandvars:0

generators:
  generator1:
    interpreter: python3
    command: testgen.py

targets:
  default:
    generate:
      - $TESTGEN_ENV_VAR
    toplevel: na

generate:
  testgen:
    generator: generator1
```