### PR TITLE
Fix deprecated sphinx html_context usage in conf.py

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -130,12 +130,9 @@ except ImportError:
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ["_static"]
 
-html_context = {
-    "css_files": [
-        # override wide tables in RTD theme
-        "_static/theme_overrides.css",
-    ]
-}
+html_css_files = [
+    "_static/theme_overrides.css",  # Fix wide tables in RTD theme
+]
 
 # Custom sidebar templates, must be a dictionary that maps document names
 # to template names.


### PR DESCRIPTION
We were using the old html_context which has been deprecated
for a while. This PR switches to html_css_files instead.
See sphinx-doc/sphinx#8885 for more information.