### PR TITLE
Avoid the use of "fusesoc init"

### DIFF
--- a/doc/source/user/package_manager/index.rst
+++ b/doc/source/user/package_manager/index.rst
@@ -20,7 +20,7 @@ there, it will search next in ``$XDG_CONFIG_HOME/fusesoc`` (i.e.
 ``~/.config/fusesoc`` on Linux and ``%HOMEPATH%\.config\fusesoc`` on
 Windows) and lastly in ``/etc/fusesoc``
 
-By running ``fusesoc init`` after FuseSoC is installed, the standard
+By running ``fusesoc library add fusesoc_cores https://github.com/fusesoc/fusesoc-cores`` after FuseSoC is installed, the standard
 libraries will be installed, and a default configuration file will be
 created in ``$XDG_CONFIG_HOME/fusesoc/fusesoc.conf`` on Linux and ``%HOMEPATH%\.config\fusesoc\fusesoc.conf`` on
 Windows with the following

--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,7 @@ deps =
 # directory, and clears it out after each test.
 commands =
     /bin/rm -rf {toxworkdir}/.tmp/homedir
-    fusesoc init -y
+    fusesoc library add fusesoc_cores https://github.com/fusesoc/fusesoc-cores
     fusesoc list-cores
     fusesoc library update
     pytest {posargs:-vv}


### PR DESCRIPTION
`fusesoc init` is deprecated, do not use it in the docs or in our
testing.