### PR TITLE
Add errors key for targets to report error conditions

### DIFF
--- a/fusesoc/capi2/core.py
+++ b/fusesoc/capi2/core.py
@@ -335,6 +335,10 @@ class Core:
             depends += [Vlnv(d) for d in self._parse_list(flags, fs.depend)]
         return depends
 
+    def get_errors(self, flags):
+        target = self._get_target(flags)
+        return self._parse_list(flags, target.errors) if target else []
+
     def get_files(self, flags):
         src_files = []
         for fs in self._get_filesets(flags):
@@ -768,6 +772,9 @@ Target:
       type : StringWithUseFlagsOrList
       desc : Top-level module. Normally a single module/entity but can be a list of several items
   lists:
+    - name : errors
+      type : StringWithUseFlags
+      desc : Error conditions. Any expression that evaluates to a non-empty string will cause FuseSoC to exit with the string as an error message
     - name : filesets
       type : StringWithUseFlags
       desc : File sets to use in target

--- a/fusesoc/edalizer.py
+++ b/fusesoc/edalizer.py
@@ -113,6 +113,10 @@ class Edalizer:
     def setup_cores(self):
         """ Setup cores: fetch resources, patch them, etc. """
         for core in self.cores:
+            flags = self._core_flags(core)
+            errors = core.get_errors(flags)
+            if errors:
+                raise RuntimeError("\n".join(errors))
             logger.info("Preparing " + str(core.name))
             core.setup()
 

--- a/tests/capi2_cores/misc/errors.core
+++ b/tests/capi2_cores/misc/errors.core
@@ -1,0 +1,18 @@
+CAPI=2:
+# Copyright FuseSoC contributors
+# Licensed under the 2-Clause BSD License, see LICENSE for details.
+# SPDX-License-Identifier: BSD-2-Clause
+
+name : ::errors:0
+
+targets:
+  no_errors: {}
+  false_error:
+    errors: ["condition_is_false? (I am not Error)"]
+  true_error:
+    errors: ["condition_is_true? (I am Error)"]
+  multiple_errors:
+    errors:
+      - "condition_is_true? (I am Error)"
+      - "condition_is_false? (I am not Error)"
+      - "I am also Error"

--- a/tests/test_capi2.py
+++ b/tests/test_capi2.py
@@ -151,6 +151,30 @@ def test_capi2_get_depends():
         assert result[i] == expected[i]
 
 
+def test_capi2_errors():
+    from fusesoc.core import Core
+
+    core_file = os.path.join(tests_dir, "capi2_cores", "misc", "errors.core")
+    core = Core(core_file)
+
+    flags = {
+        "condition_is_false": False,
+        "condition_is_true": True,
+        "is_toplevel": True,
+        "target": "no_errors",
+    }
+    assert [] == core.get_errors(flags)
+
+    flags["target"] = "false_error"
+    assert [] == core.get_errors(flags)
+
+    flags["target"] = "true_error"
+    assert ["I am Error"] == core.get_errors(flags)
+
+    flags["target"] = "multiple_errors"
+    assert ["I am Error", "I am also Error"] == core.get_errors(flags)
+
+
 def test_capi2_get_files():
     from fusesoc.core import Core
 


### PR DESCRIPTION
This adds a new key to targets named 'errors' and a get_errors CAPI
function. Any item in the errors list that evaluates to a non-empty
string will be treated as an error condition and the string will be
printed out before exiting FuseSoC. Use-cases include erroring out for
unsupported combinations of flags, or disallowing the use of certain simulators