### PR TITLE
Setup and document the use of sphinx-autobuild

### DIFF
--- a/doc/source/dev/devsetup.rst
+++ b/doc/source/dev/devsetup.rst
@@ -98,14 +98,15 @@ Building the documentation
 The FuseSoC documentation (i.e., the thing you're reading right now) is built from files in the ``doc`` directory in the FuseSoC source repository.
 The documentation is written `reStructuredText <https://docutils.readthedocs.io/en/sphinx-docs/user/rst/quickstart.html>`_, and `Sphinx <https://www.sphinx-doc.org/>`_ is used to convert the documentation into different output formats, such as HTML or PDF.
 
-Use the following command to build the documentation on your machine after making changes to it.
-The rendered documentation can be previewed by pointing a browser to the output file as shown in the run output, typically ``.tox/docs_out/index.html`` in the current directory.
-
+The most convenient way of working on documentation is to have a browser window open with the rendered documentation next an editor where you work on the reStructuredText files.
+Run the following command to build the documentation:
 
 .. code-block:: bash
 
    cd fusesoc/source/directory
-   tox -e doc
+   tox -e doc-autobuild
 
-   # On Linux: Open the rendered documentaton with the standard browser
-   xdg-open .tox/docs_out/index.html
+The documentation is now built and can be accessed in a browser.
+Look for a line similar to ``[sphinx-autobuild] Serving on http://127.0.0.1:8000`` and point your browser to the link, e.g. ``http://127.0.0.1:8000``.
+
+Whenever a change to a documentation file is detected the documentation will be rebuilt automatically and the refreshed in the browser without the need for further manual action (it might take a couple seconds, though).

--- a/fusesoc/capi2/core.py
+++ b/fusesoc/capi2/core.py
@@ -710,7 +710,7 @@ Root:
       desc : Available VPI modules
 
 Fileset:
-  description : A fileset represents a group of file with a common purpose. Each file in the fileset is required to have a file type and is allowed to have a logical_name which can be set for the whole fileset or individually for each file. A fileset can also have dependencies on other cores, specified in the depend section
+  description : A fileset represents a group of files with a common purpose. Each file in the fileset is required to have a file type and is allowed to have a logical_name which can be set for the whole fileset or individually for each file. A fileset can also have dependencies on other cores, specified in the depend section
   members:
     - name : file_type
       type : String

--- a/tox.ini
+++ b/tox.ini
@@ -43,6 +43,26 @@ commands =
     sphinx-build -d "{toxworkdir}/docs_doctree" ./doc/source "{toxworkdir}/docs_out" --color -bhtml {posargs}
     python -c 'import pathlib; print("The HTML documentation is available at file://\{0\}".format(pathlib.Path(r"{toxworkdir}") / "docs_out" / "index.html"))'
 
+[testenv:doc-autobuild]
+description = Automatically (re-)build the HTML documentation with Sphinx
+deps =
+    -rdoc/requirements.txt
+    sphinx-autobuild
+commands =
+    # capi2.rst is generated during the documentation build and would
+    # immediately re-trigger a build. We ignore the generated file, and instead
+    # watch the primary source of information for the generated file. Since
+    # capi2.rst is also produced from some other files this check isn't fully
+    # exhaustive, but covers most use cases.
+    sphinx-autobuild \
+        --open-browser \
+        -d "{toxworkdir}/docs_doctree" \
+        --ignore "*/doc/source/ref/capi2.rst" \
+        --watch "fusesoc/capi2" \
+        doc/source \
+        "{toxworkdir}/docs_out" \
+        {posargs}
+
 [gh-actions]
 # Mapping between the Python version used in GitHub Actions matrix builds, and
 # the used Tox environment.

--- a/tox.ini
+++ b/tox.ini
@@ -40,7 +40,13 @@ whitelist_externals =
 description = Build the HTML documentation with Sphinx
 deps = -rdoc/requirements.txt
 commands =
-    sphinx-build -d "{toxworkdir}/docs_doctree" ./doc/source "{toxworkdir}/docs_out" --color -bhtml {posargs}
+    sphinx-build \
+        --color \
+        -bhtml \
+        -d "{toxworkdir}/docs_doctree" \
+        doc/source \
+        "{toxworkdir}/docs_out" \
+        {posargs}
     python -c 'import pathlib; print("The HTML documentation is available at file://\{0\}".format(pathlib.Path(r"{toxworkdir}") / "docs_out" / "index.html"))'
 
 [testenv:doc-autobuild]


### PR DESCRIPTION
sphinx-autobuild builds the documentation, serves it on a localhost web
server, automatically rebuilds it when changes are detected, and also
refreshes the web page automatically. With this setup documentation
writers can have the documentation open in their browser, change
documentation source code, and see the updated documentation as soon as
they save the source file, without any other action needed. Beautiful!
    
Add the tox setup for this, and document it as the preferred way of
working on documentation. The more manual way remains in place for now.

Additionally, this PR contains small two cleanup commits that I came across.