### PR TITLE
Document use flags, and recommend quoted YAML strings

### DIFF
--- a/doc/source/ref/glossary.rst
+++ b/doc/source/ref/glossary.rst
@@ -8,6 +8,11 @@ This glossary section explains some of the jargon used.
 .. glossary::
    :sorted:
 
+   CAPI2
+      Short for "Core API version 2."
+      The schema or "language" used in :term:`core files <core file>`.
+      The :ref:`ref_capi2` describes the syntax in detail.
+
    core
       A core is a reasonably self-contained, reusable piece of IP, such as a FIFO implementation.
       See also :ref:`ug_overview_cores`.
@@ -15,6 +20,8 @@ This glossary section explains some of the jargon used.
    core file
    core description file
       A file describing a :term:`core`, including source files, available targets, etc.
+      A core file is a :term:`YAML` file which follows :term:`CAPI2` schema.
+      Core files names must end in ``.core``.
 
    semantic versioning
    SemVer

--- a/doc/source/user/build_system/core_files.rst
+++ b/doc/source/user/build_system/core_files.rst
@@ -9,6 +9,8 @@ Core files are written in :term:`YAML` syntax and follow the FuseSoC's own CAPI 
 Don't worry: using FuseSoC neither requires a full understanding of YAML, nor an up-front knowledge of CAPI.
 However, some key facts about YAML are important.
 
+.. _ug_build_system_core_files_yaml_intro:
+
 Things one should know about YAML
 ---------------------------------
 
@@ -24,29 +26,44 @@ Things one should know about YAML
 
   .. code-block:: yaml
 
-     [ item1, item2 ]
+     [ "item1", "item2" ]
 
   is semantically identical to
 
   .. code-block:: yaml
 
-     - item1
-     - item2
+     - "item1"
+     - "item2"
 
   The same is true for dictionaries (key/value pairs).
 
   .. code-block:: yaml
 
-     { key1: value1, key2: value2 }
+     { key1: "value1", key2: "value2" }
 
   is semantically identical to
 
   .. code-block:: yaml
 
-     key1: value1
-     key2: value2
+     key1: "value1"
+     key2: "value2"
 
   In most cases, the longer (second) form is preferred, as it is easier to make changes while keeping the diff easy to read.
+
+* **We recommend always adding double quotes around strings used as value.**
+  In most cases, strings in YAML do not need to be surrounded by (single or double) quotation marks.
+  However, the exact rules when quoting is needed are not easily summarized without in-depth understanding of the YAML language syntax.
+  At minimum quotation marks are *required* when strings start with an exclamation mark.
+  Always using double quotes avoids having to even think about the exact rules.
+
+  Examples:
+
+  .. code-block:: yaml
+
+     recommended: "quotedvalue"
+     required: "!tool_verilator (something)"
+     possible: unquotedvalue
+
 
 For a quick introduction into most of YAML's features have a look at `Learn YAML in Y minutes <https://learnxinyminutes.com/docs/yaml/>`_.
 The full YAML 1.2 specification is available at `yaml.org <https://yaml.org/spec/1.2/spec.html>`_ (it's not an easy read, though).

--- a/doc/source/user/build_system/flags.rst
+++ b/doc/source/user/build_system/flags.rst
@@ -3,6 +3,182 @@
 Flags: constraints in dependencies
 ==================================
 
-.. todo::
+Flags in FuseSoC are global boolean variables that influence the dependency resolution and other aspects of the build.
+Flags can be used in multiples places in :term:`core files <core file>` to take conditional actions.
+For example, dependencies and files can be included depending on a flag, different toplevels can be selected, and much more.
 
-   Document flags.
+Facts about flags:
+
+* Flags are boolean variables, they are either "set" (true) or "unset" (false).
+* Flags are global, i.e. they apply to the whole build.
+  All cores see the same flags under the same name.
+* A valid flag name starts with a letter, and consists only of letters from the English alphabet, numbers, and the underscore (``_``).
+* Flag names are case-sensitive.
+  It is recommended to use lower-case letters only.
+
+Setting flags
+-------------
+
+Built-in flags are made available automatically.
+User-defined flags can be set on the command line and override built-in flags.
+
+Built-in flags
+~~~~~~~~~~~~~~
+
+When running ``fusesoc run`` some flags are automatically made available.
+
+* ``tool_TOOLNAME``: A flag that is set only if a particular tool is used during the build process.
+  ``TOOLNAME`` is replaced with the name of the used tool.
+  For example, when building a design for Xilinx Vivado, ``tool_vivado`` will be set.
+* ``target_TARGETNAME``: A flag that is set if a particular target is being built.
+  ``TARGETNAME`` is replaced with the name of the target that is being built.
+  For example, if the target ``synth`` is being built, the flag ``target_synth`` will be set.
+
+User-defined flags
+~~~~~~~~~~~~~~~~~~
+
+Flags can be set when building a design with ``fusesoc run`` by passing the ``--flag`` argument.
+
+To set a flag, specify only the flag name, or alternatively, prefix it with a plus, i.e. ``--flag FLAGNAME`` or ``--flag +FLAGNAME``.
+To unset a flag, prefix the name of the flag with a hyphen, i.e. pass ``--flag -FLAGNAME``.
+
+The ``--flag`` argument can be used multiple times to set or unset more than one flag.
+
+Examples:
+
+.. code:: bash
+
+  # Set the flag "my_flag".
+  fusesoc run --flag "my_flag" fusesoc:examples:blinky:1.0.0
+
+  # Alternative: set the flag "my_flag"
+  fusesoc run --flag "+my_flag" fusesoc:examples:blinky:1.0.0
+
+  # Set two flags, "my_flag" and "my_other_flag"
+  fusesoc run --flag "my_flag" --flag "my_other_flag" fusesoc:examples:blinky:1.0.0
+
+  # Unset the flag "my_flag"
+  fusesoc run --flag "-my_flag" fusesoc:examples:blinky:1.0.0
+
+.. note::
+
+  Order matters!
+  The FuseSoC command line is "context sensitive."
+  Place the ``--flags`` argument after the ``run`` command, but before the name of the core you are building.
+
+
+Using flags
+-----------
+
+Flags can be used in :term:`core files <core file>` to influence the build as part of a CAPI2 expression.
+
+* To test if a flag is set (true) and return ``my_string`` in that case, use the expression ``my_flag ? (my_string)``.
+* To test if a flag is not set (false) and return ``my_string`` in that case, use the expression ``!my_flag ? (my_string)``.
+
+.. note::
+   **Quotation marks are required** for strings starting with an exclamation mark (``!``), but :ref:`always recommended <ug_build_system_core_files_yaml_intro>`.
+
+CAPI2 expressions are *not* full ternary operators, i.e. no "else" branch is available.
+Use two inverted expressions for if/else support.
+
+The following use cases show some ways in which flags can be used in core description files.
+
+
+Use case: Conditional dependencies
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Flags can be used to influence which dependencies are included in a build.
+A typical use case for this feature are dependencies which are tool-specific.
+
+The following example shows how to depend on a core named ``fusesoc:examples:xilinx-fifo`` (presumably implementing a Xilinx-specific FIFO) only if the ``vivado`` tool is used.
+Otherwise a core providing a tool-agnostic implementation is used.
+
+.. code-block:: yaml
+
+   # An excerpt from a core file.
+   filesets:
+     rtl:
+       # ...
+       depend:
+         - "tool_vivado ? (fusesoc:examples:xilinx-fifo)"
+         - "!tool_vivado ? (fusesoc:examples:generic-fifo)"
+
+
+Use case: Conditionally include files
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Similar to the way dependencies can be conditionally specified source files can also be included conditionally.
+
+The following example shows how to include a file ``rtl/fifo_xilinx.sv`` only if Vivado is used, and ``rtl/fifo_generic.sv`` otherwise.
+
+.. code-block:: yaml
+
+   # An excerpt from a core file.
+   filesets:
+     rtl:
+       # ...
+       files:
+         - "tool_vivado ? (rtl/fifo_xilinx.sv)"
+         - "!tool_vivado ? (rtl/fifo_generic.sv)"
+
+
+Use case: Conditional filesets in a target
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Use flags in CAPI2 expressions in the ``targets.TARGETNAME.filesets`` block to conditionally include file sets.
+
+The code snippet below shows how to include a fileset ``verilator_tb`` only if the ``verilator`` tool is used;
+otherwise the fileset ``any_other_tool_tb`` is included.
+
+.. code-block:: yaml
+
+   # An excerpt from a core file.
+   targets:
+     # ...
+     tb:
+       # ...
+       filesets:
+         # Always include the rtl and tb filesets.
+         - "rtl"
+         - "tb"
+         # Include the verilator_tb fileset only if verilator is used.
+         - "tool_verilator ? (verilator_tb)"
+         # Include the any_other_tool_tb fileset for all other tools.
+         - "!tool_verilator ? (any_other_tool_tb)"
+
+
+Use case: Conditionally choose a toplevel
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Flags can also be used to choose the name a design toplevel based on certain conditions.
+
+In the following code snippet, the user-defined flag ``experimental_toplevel`` is used to switch between two toplevels.
+
+.. code-block:: yaml
+
+   # An excerpt from a core file.
+   name: "fusesoc:examples:my_core"
+   targets:
+     # ...
+     synth:
+       toplevel:
+         - "experimental_toplevel ? (top_experimental)"
+         - "!experimental_toplevel ? (top_production)"
+       # ...
+
+With this setup in place users can choose which toplevel they want to build by passing the ``--flag`` command line argument to ``fusesoc``, as illustrated in the following example.
+
+.. code-block:: bash
+
+  # Build top_experimental
+  fusesoc run --flag experimental_toplevel --target synth fusesoc:examples:my_core
+
+  # Build top_production
+  fusesoc run --target synth fusesoc:examples:my_core
+
+Further use cases
+~~~~~~~~~~~~~~~~~
+
+Flags can be used in more places than shown here.
+To find all valid places where flags can be used, refer to the :ref:`ref_capi2`.
+Expressions with flags can be used whenever the data type is ``StringWithUseFlags``, ``StringWithUseFlagsOrDict``, or ``StringWithUseFlagsOrList``.

--- a/fusesoc/capi2/core.py
+++ b/fusesoc/capi2/core.py
@@ -984,12 +984,15 @@ StringWithUseFlags
 
 StringWithUseFlags is a string that can contain CAPI2 expressions that are evaluated during parsing.
 
-CAPI2 expressions are used to evaluate an expression only if a flag is set or unset.
-The general form is *flag_is_set ? ( expression )* to evaluate *expression* if flag is set or *!flag_is_set ? ( expression )* to evaluate *expression* if flag is not set.
+CAPI2 expressions return a value depending on a :ref:`flag <ug_build_system_flags>` being set or not.
 
-**Example** Only include fileset *verilator_tb* when the target is used with verilator
+* To test if a flag is set (true) and return ``my_string`` in that case, use the expression ``my_flag ? (my_string)``.
+* To test if a flag is not set (false) and return ``my_string`` in that case, use the expression ``!my_flag ? (my_string)``.
 
-``filesets : [rtl, tb, tool_verilator? (verilator_tb)]``
+.. note::
+   **Quotation marks are required** for strings starting with an exclamation mark (``!``), but :ref:`always recommended <ug_build_system_core_files_yaml_intro>`.
+
+Refer to the section :ref:`ug_build_system_flags` in the User Guide for more information on flags.
 
 StringWithUseFlagsOrDict
 ~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
This PR contains two commits which depend on each other, but are different topics:

- The first commit recommends to always quote strings used as value in CAPI2 files. This gives our users a single, always-right and easy to remember rule on what to do with strings. All other rules are more complex ("quote some strings, but not others") and easy to get wrong (as multiple support requests I've gotten over the recent months have shown).
- The second commit documents flags and their uses in FuseSoC, filling a gap in the documentation.