### PR TITLE
Remove Sphinx from dev-requirements.txt, add tox

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,6 +1,8 @@
 # Python requirements needed to develop fusesoc
 # "End-user" dependencies (during build or install time) are listed in setup.py
 pre-commit>=2.9.0
+
+# It is recommended to run pytest through tox, in which case this dependency is
+# not needed.
 pytest>=3.3.0
-Sphinx
-sphinx_rtd_theme
+tox


### PR DESCRIPTION
The recommended way of building the documentation locally is through
tox. Avoid installing Sphinx for "manual" development environments, tox
already takes care of that.

Add tox as development dependency (it was missing before), and remove
the manual installation of Sphinx.

For now we keep pytest as separate dependency, even though that's not
needed when running tests through tox.