### PR TITLE
Add Integer class for edalize

### DIFF
--- a/fusesoc/capi2/core.py
+++ b/fusesoc/capi2/core.py
@@ -65,6 +65,8 @@ class String(str):
             "https://github.com/olofk/fusesoc/issues/new."
         )
 
+class Integer(int):
+    pass
 
 class StringWithUseFlagsOrList:
     def __new__(cls, *args, **kwargs):


### PR DESCRIPTION
This commit add basic Integer class to support Integer type parameters for back ends defined in edalize. For example: jobs parameter of Vivado. Please see Issue #515 https://github.com/olofk/fusesoc/issues/515

Fixes #515 