### PR TITLE
Improved tool options parsing

### DIFF
--- a/fusesoc/capi2/core.py
+++ b/fusesoc/capi2/core.py
@@ -319,12 +319,14 @@ class Core:
                 if hasattr(section, member):
                     _member = getattr(section, member)
                     if _member:
-                        options[member] = str(_member)
+                        options[member] = StringWithUseFlags(_member).parse(flags)
             for member in section.lists:
                 if hasattr(section, member):
                     _member = getattr(section, member)
                     if _member:
-                        options[member] = [str(x) for x in _member]
+                        options[member] = [
+                            StringWithUseFlags(x).parse(flags) for x in _member
+                        ]
         self._debug("Found tool options {}".format(str(options)))
         return options
 

--- a/fusesoc/capi2/core.py
+++ b/fusesoc/capi2/core.py
@@ -319,13 +319,16 @@ class Core:
                 if hasattr(section, member):
                     _member = getattr(section, member)
                     if _member:
-                        options[member] = StringWithUseFlags(_member).parse(flags)
+                        options[member] = StringWithUseFlags(
+                            os.path.expandvars(_member)
+                        ).parse(flags)
             for member in section.lists:
                 if hasattr(section, member):
                     _member = getattr(section, member)
                     if _member:
                         options[member] = [
-                            StringWithUseFlags(x).parse(flags) for x in _member
+                            StringWithUseFlags(os.path.expandvars(x)).parse(flags)
+                            for x in _member
                         ]
         self._debug("Found tool options {}".format(str(options)))
         return options


### PR DESCRIPTION
This PR handles two issues:

1. A use flag inside a tool option meant the entry was passed to the tool verbatim. This PR turns the bare string into a StringWithUseFlags and parses it with the flags
2. An environment variable inside a tool option meant the entry would not parse. This PR does `os.path.expandvars()` to expand any environment variables
