### PR TITLE
Support virtual packages in CAPI2

### DIFF
--- a/fusesoc/capi2/core.py
+++ b/fusesoc/capi2/core.py
@@ -65,8 +65,10 @@ class String(str):
             "https://github.com/olofk/fusesoc/issues/new."
         )
 
+
 class Integer(int):
     pass
+
 
 class StringWithUseFlagsOrList:
     def __new__(cls, *args, **kwargs):
@@ -361,6 +363,10 @@ class Core:
             generators[k].root = self.files_root
             self._debug(" Found generator " + k)
         return generators
+
+    def get_virtuals(self):
+        """ Get a list of "virtual" VLNVs provided by this core. """
+        return self.virtual
 
     def get_parameters(self, flags={}, ext_parameters={}):
         def _parse_param_value(name, datatype, default):
@@ -710,6 +716,10 @@ Root:
     - name : vpi
       type : Vpi
       desc : Available VPI modules
+  lists:
+    - name : virtual
+      type : Vlnv
+      desc : VLNV of a virtual core provided by this core. Versions are currently not supported, only the VLN part is used.
 
 Fileset:
   description : A fileset represents a group of files with a common purpose. Each file in the fileset is required to have a file type and is allowed to have a logical_name which can be set for the whole fileset or individually for each file. A fileset can also have dependencies on other cores, specified in the depend section

--- a/tests/capi2_cores/virtual/impl1.core
+++ b/tests/capi2_cores/virtual/impl1.core
@@ -1,0 +1,19 @@
+CAPI=2:
+# Copyright FuseSoC contributors
+# Licensed under the 2-Clause BSD License, see LICENSE for details.
+# SPDX-License-Identifier: BSD-2-Clause
+
+name: ::impl1:0
+virtual:
+  - ::someinterface:0
+filesets:
+  rtl:
+    files:
+      - impl1.sv
+    file_type: systemVerilogSource
+
+
+targets:
+  default:
+    filesets:
+      - rtl

--- a/tests/capi2_cores/virtual/impl2.core
+++ b/tests/capi2_cores/virtual/impl2.core
@@ -1,0 +1,19 @@
+CAPI=2:
+# Copyright FuseSoC contributors
+# Licensed under the 2-Clause BSD License, see LICENSE for details.
+# SPDX-License-Identifier: BSD-2-Clause
+
+name: ::impl2:0
+virtual:
+  - ::someinterface:0
+filesets:
+  rtl:
+    files:
+      - impl2.sv
+    file_type: systemVerilogSource
+
+
+targets:
+  default:
+    filesets:
+      - rtl

--- a/tests/capi2_cores/virtual/user.core
+++ b/tests/capi2_cores/virtual/user.core
@@ -1,0 +1,20 @@
+CAPI=2:
+# Copyright FuseSoC contributors
+# Licensed under the 2-Clause BSD License, see LICENSE for details.
+# SPDX-License-Identifier: BSD-2-Clause
+
+name: ::user:0
+filesets:
+  rtl:
+    depend:
+      - ::someinterface:0
+    files:
+      - user.sv
+    file_type: systemVerilogSource
+
+
+targets:
+  default:
+    filesets:
+      - rtl
+    toplevel: user

--- a/tests/test_capi2.py
+++ b/tests/test_capi2.py
@@ -46,6 +46,15 @@ def test_empty_core():
     assert "Error while trying to parse the core file" in str(excinfo.value)
 
 
+def test_virtual():
+    from fusesoc.core import Core
+    from fusesoc.vlnv import Vlnv
+
+    core_file = os.path.join(tests_dir, "capi2_cores", "virtual", "impl1.core")
+    core = Core(core_file)
+    assert core.get_virtuals() == [Vlnv("::someinterface:0")]
+
+
 def test_capi2_export():
     import os
     import tempfile

--- a/tests/test_coremanager.py
+++ b/tests/test_coremanager.py
@@ -219,3 +219,40 @@ def test_export():
         "wb_intercon_1.0/rtl/verilog/wb_upsizer.v",
     ]:
         assert os.path.isfile(os.path.join(export_root, f))
+
+
+def test_virtual():
+    import os
+    import tempfile
+
+    from fusesoc.config import Config
+    from fusesoc.coremanager import CoreManager
+    from fusesoc.edalizer import Edalizer
+    from fusesoc.librarymanager import Library
+    from fusesoc.vlnv import Vlnv
+
+    flags = {"tool": "icarus"}
+
+    build_root = tempfile.mkdtemp(prefix="export_")
+    work_root = os.path.join(build_root, "work")
+
+    core_dir = os.path.join(os.path.dirname(__file__), "capi2_cores", "virtual")
+
+    cm = CoreManager(Config())
+    cm.add_library(Library("virtual", core_dir))
+
+    root_core = cm.get_core(Vlnv("::user"))
+
+    edalizer = Edalizer(
+        toplevel=root_core.name,
+        flags=flags,
+        cache_root=None,
+        core_manager=cm,
+        work_root=work_root,
+    )
+    edalizer.run()
+
+    deps = cm.get_depends(root_core.name, {})
+    deps_names = [str(c) for c in deps]
+
+    assert deps_names == ["::impl2:0", "::user:0"]


### PR DESCRIPTION
Packages can now provide more than one package: they provide itself (as
described by the package `name`), and a list of further (virtual)
packages, described by the `virtual` key in the root of the CAPI2 file.

Example:
```
CAPI=2:
name: ::impl2:0
virtual:
  - ::someinterface:0
```

This core provides a core named `::impl2:0` and a core named
`someinterface:0`. Other cores can now depend either `::impl2:0` or
`::someinterface` and always get the `::impl2:0` core.

The keyword `virtual` was chosen over alternatives, such as `provide` to
be distinct from other keywords we use in CAPI2 currently, especially to
be distinct from the concept of providers.

Fixes #235