### PR TITLE
Tox: More selectively remove directories

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -13,15 +13,15 @@ deps =
 # directory, but creates an isolated home directory within the tox working
 # directory, and clears it out after each test.
 commands =
-    /bin/rm -rf {toxworkdir}/.tmp/homedir
-    fusesoc library add fusesoc_cores https://github.com/fusesoc/fusesoc-cores
+    /bin/rm -rf {toxworkdir}/.tmp/homedir/.cache {toxworkdir}/.tmp/homedir/.local/share {toxworkdir}/.tmp/homedir/.config
+    mkdir -p {toxworkdir}/.tmp/homedir/.config/fusesoc
+    fusesoc --verbose library add --global fusesoc_cores https://github.com/fusesoc/fusesoc-cores
     fusesoc list-cores
     fusesoc library update
     pytest {posargs:-vv}
 
 setenv =
     MODEL_TECH = dummy_value
-    HOME = {toxworkdir}/.tmp/homedir
     XDG_CACHE_HOME = {toxworkdir}/.tmp/homedir/.cache
     XDG_DATA_HOME= {toxworkdir}/.tmp/homedir/.local/share
     XDG_CONFIG_HOME = {toxworkdir}/.tmp/homedir/.config
@@ -31,6 +31,7 @@ passenv =
 
 whitelist_externals =
   /bin/rm
+  /usr/bin/mkdir
 
 [testenv:doc]
 # Note: this target is *not* used by ReadTheDocs, which runs sphinx-build


### PR DESCRIPTION
Avoid removing the full (tox-created) HOME directory, as it may contain
Python venv components that we are unable to delete at times.

Fixes #546