### PR TITLE
CI: Add Python 3.11 (alpha for now)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,7 @@ jobs:
           - '3.8'
           - '3.9'
           - '3.10'
+          - '3.11.0-alpha - 3.11.0'
     runs-on: ${{ matrix.os.name }}
     name: ${{ matrix.os.icon }} ${{ matrix.os.name }} | ${{ matrix.pyver }}
     steps:


### PR DESCRIPTION
Python 3.11 is in alpha now, but having it in CI helps us be prepared.
CI will always pick up the latest 3.11 version as it moves from alpha to
beta to release ultimately.