### PR TITLE
feat_board_file_support: fix for missing copytree

### DIFF
--- a/fusesoc/capi2/core.py
+++ b/fusesoc/capi2/core.py
@@ -236,13 +236,19 @@ class Core:
                 )
             if not os.path.isabs(f):
                 if os.path.exists(os.path.join(self.core_root, f)):
-                    shutil.copyfile(
-                        os.path.join(self.core_root, f), os.path.join(dst_dir, f)
-                    )
+                    src = os.path.join(self.core_root, f)
+                    dst = os.path.join(dst_dir, f)
+                    try:
+                        shutil.copyfile(src, dst)
+                    except IsADirectoryError:
+                        shutil.copytree(src, dst, dirs_exist_ok=True)
                 elif os.path.exists(os.path.join(self.files_root, f)):
-                    shutil.copyfile(
-                        os.path.join(self.files_root, f), os.path.join(dst_dir, f)
-                    )
+                    src = os.path.join(self.files_root, f)
+                    dst = os.path.join(dst_dir, f)
+                    try:
+                        shutil.copyfile(src, dst)
+                    except IsADirectoryError:
+                        shutil.copytree(src, dst, dirs_exist_ok=True)
                 else:
                     raise RuntimeError(
                         "Cannot find %s in :\n\t%s\n\t%s"


### PR DESCRIPTION
 - there are two locations in the codebase where file copying takes place depending
   on whether you run fusesoc with the --no-export switch.