### PR TITLE
Tweak test_edalizer not to depend on the order of edalizer.cores

### DIFF
--- a/tests/test_edalizer.py
+++ b/tests/test_edalizer.py
@@ -36,9 +36,12 @@ def test_generators():
     )
     edalizer.run()
 
-    gendir = edalizer.cores[-3].core_root
-    assert os.path.isfile(os.path.join(gendir, "generated.core"))
-    assert os.path.isfile(os.path.join(gendir, "testgenerate_without_params_input.yml"))
-    gendir = edalizer.cores[-2].core_root
-    assert os.path.isfile(os.path.join(gendir, "generated.core"))
-    assert os.path.isfile(os.path.join(gendir, "testgenerate_with_params_input.yml"))
+    name_to_core = {str(core.name): core for core in edalizer.cores}
+    for flavour in ["testgenerate_with_params", "testgenerate_without_params"]:
+        core_name = f"::generate-{flavour}:0"
+        assert core_name in name_to_core
+        core = name_to_core[core_name]
+
+        gendir = core.core_root
+        assert os.path.isfile(os.path.join(gendir, "generated.core"))
+        assert os.path.isfile(os.path.join(gendir, f"{flavour}_input.yml"))


### PR DESCRIPTION
This didn't matter until 0469da4 because all the 'core_root' paths
were the same. But generated cores now appear in different directories
from one another so we have to get it right.

Note that this isn't actually required for upstream at the moment: it's probably nice to be more robust, but things were working anyway. But it *is* required for some local changes we've got on our OpenTitan fork where @imphil's patch reorders generated cores a bit (and the "-3" and "-2" indices were then wrong).