### PR TITLE
Enable Edalize flow API support

### DIFF
--- a/doc/source/user/build_system/flow_options.rst
+++ b/doc/source/user/build_system/flow_options.rst
@@ -1,0 +1,33 @@
+.. _ug_build_system_flow_options:
+
+Configuring a flow
+==================
+
+FuseSoC uses `Edalize <https://github.com/olofk/edalize>`_ to chain together and run EDA tools. Edalize supports many different EDA tools and combinations of tools working together, called flows. A flow could e.g. be an FPGA bitstream flow where one EDA tool is used for synthesis, another one for place & route and a third one to convert the P&R database into an image that can be loaded into the FPGA. Another example could be a simulation flow, where the simulator itself is just one tool, but where a code conversion tool is used to preprocess the input to the simulator, e.g. ghdl to convert VHDL to Verilog for tools that don't handle the former well enough.
+
+FuseSoC abstracts away many differences between :term:`tools <tool>` and tries to provide sane defaults to build many designs out of the box with no further configuration required. However, not all tool-specific details can be hidden.
+
+At the same time, a certain level of tool-specific configurability is required to make full use of the features available in different tools.
+
+There are two categories of options available for the Edalize backends. *Flow options* that affect how the tools are chained together (the flow graph) and *tool options* for the individual tools to be run as part of the flow. This means that since the flow options influence which tools that will be run, some tool options only become available for certain combinations of flow options.
+
+The example below shows how the `test` target selects and configures a flow. The `flow` key selectes the flow itself. The selected `sim` flow has a *flow option* called `sim` that decides which simulator to use. `iverilog_options` and `vlog_options` are tool options for Icarus Verilog and Siemens QuestaSim/ModelSim and will be passed to the approriate tool if it's in the flow graph.
+
+This setup selects icarus as the tool, which means the `vlog_options` will not be used. However, all *flow options* and *tool options* are also automatically available on the command-line, which means that passing `--tool=modelsim` as a backend parameter will override the tool setting from the target. The same can be done for the two tool options, with the difference that for flow or tool option that are lists, any additional values passed on the command-line will append rather than replace the values in the core description file.
+
+.. code-block:: yaml
+
+   # An excerpt from a core file.
+   # ...
+   targets:
+     test:
+       # ...
+       flow: sim
+       flow_options:
+           tool: icarus
+           iverilog_options:
+             - -g2012 # Use SystemVerilog-2012
+           vlog_options:
+             - -timescale=1ns/1ns
+
+The available options for any flow can be found in the `Edalize <https://github.com/olofk/edalize>`_ documentation. They can also be found by running a target with the `--help` flag. `fusesoc run --target=<some target> <some core> --help`

--- a/doc/source/user/build_system/index.rst
+++ b/doc/source/user/build_system/index.rst
@@ -22,7 +22,11 @@ Typically, FuseSoC support can be added to an existing design without changes to
 
 The first three sections are recommended reading for all users of FuseSoC.
 The first section :ref:`ug_build_system_core_files` is an introduction into :term:`core description files <core file>` and how to write them.
-The second and third section, :ref:`ug_build_system_tool_options` and :ref:`ug_build_system_dependencies` look at how to customize what the (EDA) :term:`tools <tool>` are doing, and how cores can be combined to form a larger system.
+The second and third section, :ref:`ug_build_system_flow_options` and :ref:`ug_build_system_dependencies` look at how to customize what the (EDA) :term:`tools <tool>` are doing, and how cores can be combined to form a larger system.
+
+.. note::
+
+   Edalize has two different APIs for running EDA tool flows. The new flow API is described in :ref:`ug_build_system_flow_options` and will become the default API. However, not all Edalize backends have been converted to the new API, so the old tool API remains in use and is described in :ref:`ug_build_system_tool_options`. If FuseSoC encounters a `flow` key in the target, it will use the flow API. Otherwise it will fall back to the tool API
 
 The subsequent sections are advanced topics, which are only relevant in some projects.
 

--- a/fusesoc/capi2/core.py
+++ b/fusesoc/capi2/core.py
@@ -324,6 +324,24 @@ class Core:
                 flags["tool"] = str(target.default_tool)
         return flags
 
+    def get_flow(self, flags):
+        self._debug("Getting flow for flags {}".format(str(flags)))
+        flow = None
+        if flags.get("flow"):
+            flow = flags["flow"]
+        else:
+            _flags = flags.copy()
+            _flags["is_toplevel"] = True
+            target = self._get_target(_flags)
+            if target and target.flow:
+                flow = str(target.flow)
+
+        if flow:
+            self._debug(f" Matched flow {flow}")
+        else:
+            self._debug(" Matched no flow")
+        return flow
+
     def get_scripts(self, files_root, flags):
         self._debug("Getting hooks for flags '{}'".format(str(flags)))
         hooks = {}
@@ -368,6 +386,19 @@ class Core:
                         options[member] = [str(x) for x in _member]
         self._debug("Found tool options {}".format(str(options)))
         return options
+
+    def get_flow_options(self, flags):
+        _flags = flags.copy()
+
+        self._debug("Getting flow options for flags {}".format(str(_flags)))
+        target = self._get_target(_flags)
+
+        if target and target.flow_options:
+            self._debug(f"Found flow options {target.flow_options}")
+        else:
+            self._debug("Found no flow options")
+
+        return (target and target.flow_options) or {}
 
     def get_depends(self, flags):  # Add use flags?
         depends = []
@@ -794,6 +825,12 @@ Target:
     - name : description
       type : String
       desc : Description of the target
+    - name : flow
+      type : String
+      desc : Edalize backend flow to use for target
+    - name : flow_options
+      type : Any
+      desc : Tool- and flow-specific options
     - name : hooks
       type : Hooks
       desc : Script hooks to run when target is used

--- a/fusesoc/coremanager.py
+++ b/fusesoc/coremanager.py
@@ -254,6 +254,8 @@ class CoreManager:
                     except ImportError as e:
                         w = 'Failed to register "{}" due to unknown provider: {}'
                         logger.warning(w.format(core_file, str(e)))
+                    except ValueError as e:
+                        logger.warning(e)
         return found_cores
 
     def _detect_capi_version(self, core_file) -> int:

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ setup(
         "setuptools_scm; python_version>='3.7'",
     ],
     install_requires=[
-        "edalize>=0.2.3",
+        "edalize>=0.3.3",
         "pyparsing",
         "pyyaml",
         "simplesat>=0.8.0",

--- a/tests/capi2_cores/misc/flow.core
+++ b/tests/capi2_cores/misc/flow.core
@@ -1,0 +1,27 @@
+CAPI=2:
+name : ::flow:0
+targets:
+  nothing:
+    toplevel: unused
+  flowonly:
+    flow : icestorm
+    toplevel: unused
+  emptyflowoptions:
+    flow : lint
+    flow_options : {}
+    toplevel: unused
+  flowoptions:
+    flow : sim
+    flow_options:
+      tool1:
+        someoption : somevalue
+      tool2:
+        otheroption : [detroit, 442]
+    toplevel: unused
+  toolonly:
+    default_tool : icestorm
+    toplevel: unused
+  flowandtool:
+    default_tool : vivado
+    flow: icestorm
+    toplevel: unused

--- a/tests/test_edalizer.py
+++ b/tests/test_edalizer.py
@@ -3,6 +3,92 @@
 # SPDX-License-Identifier: BSD-2-Clause
 
 
+def test_tool_or_flow():
+    import os
+
+    from fusesoc.config import Config
+    from fusesoc.coremanager import CoreManager
+    from fusesoc.edalizer import Edalizer
+    from fusesoc.librarymanager import Library
+    from fusesoc.vlnv import Vlnv
+
+    tests_dir = os.path.dirname(__file__)
+    cores_dir = os.path.join(tests_dir, "capi2_cores", "misc")
+
+    lib = Library("edalizer", cores_dir)
+
+    cm = CoreManager(Config())
+    cm.add_library(lib, [])
+
+    core = cm.get_core(Vlnv("::flow"))
+
+    ref_edam = {
+        "version": "0.2.1",
+        "dependencies": {"::flow:0": []},
+        "files": [],
+        "hooks": {},
+        "name": "flow_0",
+        "parameters": {},
+        "tool_options": {},
+        "toplevel": "unused",
+        "vpi": [],
+        "flow_options": {},
+    }
+
+    edam = Edalizer(
+        toplevel=core.name,
+        flags={"target": "nothing"},
+        core_manager=cm,
+        work_root=".",
+    ).run()
+    assert edam == ref_edam
+
+    edam = Edalizer(
+        toplevel=core.name,
+        flags={"target": "flowonly"},
+        core_manager=cm,
+        work_root=".",
+    ).run()
+    assert edam == ref_edam
+
+    edam = Edalizer(
+        toplevel=core.name,
+        flags={"target": "emptyflowoptions"},
+        core_manager=cm,
+        work_root=".",
+    ).run()
+    assert edam == ref_edam
+
+    edam = Edalizer(
+        toplevel=core.name,
+        flags={"target": "toolonly"},
+        core_manager=cm,
+        work_root=".",
+    ).run()
+    assert edam == ref_edam
+
+    edam = Edalizer(
+        toplevel=core.name,
+        flags={"target": "flowandtool"},
+        core_manager=cm,
+        work_root=".",
+    ).run()
+    assert edam == ref_edam
+
+    edam = Edalizer(
+        toplevel=core.name,
+        flags={"target": "flowoptions"},
+        core_manager=cm,
+        work_root=".",
+    ).run()
+
+    ref_edam["flow_options"] = {
+        "tool1": {"someoption": "somevalue"},
+        "tool2": {"otheroption": ["detroit", 442]},
+    }
+    assert edam == ref_edam
+
+
 def test_generators():
     import os
     import tempfile


### PR DESCRIPTION
This enables support for the new flow API in Edalize, which will eventually supersede the current Edalize API. For now these two APIs live side by side. FuseSoC users who wish to remain on the old Edalize API doesn't need to do anything. For users wanting to use the flow API, set the `flow` key in a target to one of the supported flows, and set the `flow_options` to control flow-specific options. These two keys have precedence over the `default_tool` and `tools` keys currently used in the target section.

This is also one of the two major changes I want to get in before the FuseSoC 2.0 release, so please take a look and comment accordingly