### PR TITLE
Fix interface incompatibility in test_virtual

### DIFF
--- a/tests/test_coremanager.py
+++ b/tests/test_coremanager.py
@@ -237,7 +237,6 @@ def test_virtual():
     edalizer = Edalizer(
         toplevel=root_core.name,
         flags=flags,
-        cache_root=None,
         core_manager=cm,
         work_root=work_root,
     )


### PR DESCRIPTION
Commit 6b04028491c02308bec9423627c35b3456ea980a introduced new code
which broke a test. Fix that. (There was a mid-air collision of two
changes.)