### PR TITLE
provider clean_cache rmtree working on windows with ro files in .git

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,6 +30,6 @@ repos:
       - id: isort
         args: ["--profile", "black", "--filter-files"]
   - repo: https://github.com/psf/black
-    rev: 20.8b1
+    rev: 22.3.0
     hooks:
       - id: black

--- a/fusesoc/provider/provider.py
+++ b/fusesoc/provider/provider.py
@@ -20,7 +20,20 @@ class Provider:
         self.patches = config.get("patches", [])
 
     def clean_cache(self):
+        def _make_tree_writable(topdir):
+            # Ensure all files and directories under topdir are writable
+            # (and readable) by owner.
+            for d, _, files in os.walk(topdir):
+                os.chmod(d, os.stat(d).st_mode | stat.S_IWRITE | stat.S_IREAD)
+                for fname in files:
+                    fpath = os.path.join(d, fname)
+                    if os.path.isfile(fpath):
+                        os.chmod(
+                            fpath, os.stat(fpath).st_mode | stat.S_IWRITE | stat.S_IREAD
+                        )
+
         if os.path.exists(self.files_root):
+            _make_tree_writable(self.files_root)
             shutil.rmtree(self.files_root)
 
     def fetch(self):

--- a/fusesoc/provider/provider.py
+++ b/fusesoc/provider/provider.py
@@ -5,6 +5,7 @@
 import logging
 import os
 import shutil
+import stat
 
 from fusesoc.utils import Launcher
 


### PR DESCRIPTION
Pull request regarding issue [562](https://github.com/olofk/fusesoc/issues/562)

I did need to update the black version otherwise my pre_commit was falling all the time with a corresponding error.

