### PR TITLE
Add support for ignored directories to config files

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,2 @@
+[flake8]
+max-line-length = 88

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,6 +30,6 @@ repos:
       - id: isort
         args: ["--profile", "black", "--filter-files"]
   - repo: https://github.com/psf/black
-    rev: 20.8b1
+    rev: 22.3.0
     hooks:
       - id: black

--- a/fusesoc/capi2/core.py
+++ b/fusesoc/capi2/core.py
@@ -49,7 +49,7 @@ class Any:
 
 
 class StringWithUseFlags(str):
-    """ A parsed string with support for use flags. """
+    """A parsed string with support for use flags."""
 
     def __init__(self, string):
         self.exprs = None
@@ -61,7 +61,7 @@ class StringWithUseFlags(str):
 
 
 class String(str):
-    """ A plain (unparsed) string. """
+    """A plain (unparsed) string."""
 
     def parse(self, flags):
         raise RuntimeError(
@@ -373,7 +373,7 @@ class Core:
         return generators
 
     def get_virtuals(self):
-        """ Get a list of "virtual" VLNVs provided by this core. """
+        """Get a list of "virtual" VLNVs provided by this core."""
         return self.virtual
 
     def get_parameters(self, flags={}, ext_parameters={}):

--- a/fusesoc/config.py
+++ b/fusesoc/config.py
@@ -5,7 +5,6 @@
 import configparser
 import logging
 import os
-import sys
 from configparser import ConfigParser as CP
 
 from fusesoc.librarymanager import Library
@@ -163,7 +162,7 @@ class Config:
 
         try:
             provider = get_provider(library.sync_type)
-        except ImportError as e:
+        except ImportError:
             raise RuntimeError("Invalid sync-type '{}'".format(library["sync-type"]))
 
         provider.init_library(library)

--- a/fusesoc/config.py
+++ b/fusesoc/config.py
@@ -42,6 +42,7 @@ class Config:
         cores_root = self._get_cores_root(config)
         systems_root = self._get_systems_root(config)
         self.library_root = self._get_library_root(config)
+        self.ignored_dirs = self._get_ignored_dirs(config)
 
         os.makedirs(self.cache_root, exist_ok=True)
 
@@ -159,6 +160,9 @@ class Config:
             os.path.expanduser("~"), ".local/share"
         )
         return os.path.join(xdg_data_home, "fusesoc")
+
+    def _get_ignored_dirs(self, config):
+        return self._paths_from_cfg(config, "ignored_dirs")
 
     def add_library(self, library):
         from fusesoc.provider import get_provider

--- a/fusesoc/config.py
+++ b/fusesoc/config.py
@@ -14,7 +14,7 @@ logger = logging.getLogger(__name__)
 
 
 class Config:
-    def __init__(self, path=None, file=None):
+    def __init__(self, path=None):
         self.build_root = None
         self.cache_root = None
         cores_root = []
@@ -23,33 +23,28 @@ class Config:
         self.libraries = []
 
         config = CP()
-        if file is None:
-            if path is None:
-                xdg_config_home = os.environ.get("XDG_CONFIG_HOME") or os.path.join(
-                    os.path.expanduser("~"), ".config"
-                )
-                config_files = [
-                    "/etc/fusesoc/fusesoc.conf",
-                    os.path.join(xdg_config_home, "fusesoc", "fusesoc.conf"),
-                    "fusesoc.conf",
-                ]
-            else:
-                logger.debug(f"Using config file '{path}'")
-                if not os.path.isfile(path):
-                    with open(path, "a"):
-                        pass
-                config_files = [path]
 
-            logger.debug("Looking for config files from " + ":".join(config_files))
-            files_read = config.read(config_files)
-            logger.debug("Found config files in " + ":".join(files_read))
-            if files_read:
-                self._path = files_read[-1]
+        if path is None:
+            xdg_config_home = os.environ.get("XDG_CONFIG_HOME") or os.path.join(
+                os.path.expanduser("~"), ".config"
+            )
+            config_files = [
+                "/etc/fusesoc/fusesoc.conf",
+                os.path.join(xdg_config_home, "fusesoc", "fusesoc.conf"),
+                "fusesoc.conf",
+            ]
         else:
-            logger.debug("Using supplied config file")
-            config.read_file(file)
-            file.seek(0)
-            self._path = file.name
+            logger.debug(f"Using config file '{path}'")
+            if not os.path.isfile(path):
+                with open(path, "a"):
+                    pass
+            config_files = [path]
+
+        logger.debug("Looking for config files from " + ":".join(config_files))
+        files_read = config.read(config_files)
+        logger.debug("Found config files in " + ":".join(files_read))
+        if files_read:
+            self._path = files_read[-1]
 
         for item in ["build_root", "cache_root", "systems_root", "library_root"]:
             try:

--- a/fusesoc/coremanager.py
+++ b/fusesoc/coremanager.py
@@ -288,7 +288,7 @@ class CoreManager:
             self.db.add(core, library)
 
     def add_library(self, library):
-        """ Register a library """
+        """Register a library"""
         abspath = os.path.abspath(os.path.expanduser(library.location))
         _library = self._lm.get_library(abspath, "location")
         if _library:
@@ -300,7 +300,7 @@ class CoreManager:
         self._lm.add_library(library)
 
     def get_libraries(self):
-        """ Get all registered libraries """
+        """Get all registered libraries"""
         return self._lm.get_libraries()
 
     def get_depends(self, core, flags):
@@ -325,17 +325,17 @@ class CoreManager:
         return deps
 
     def get_cores(self):
-        """ Get a dict with all cores, indexed by the core name """
+        """Get a dict with all cores, indexed by the core name"""
         return {str(x.name): x for x in self.db.find()}
 
     def get_core(self, name):
-        """ Get a core with a given name """
+        """Get a core with a given name"""
         c = self.db.find(name)
         c.name.relation = "=="
         return c
 
     def get_generators(self):
-        """ Get a dict with all registered generators, indexed by name """
+        """Get a dict with all registered generators, indexed by name"""
         generators = {}
         for core in self.db.find():
             if hasattr(core, "get_generators"):

--- a/fusesoc/edalizer.py
+++ b/fusesoc/edalizer.py
@@ -56,7 +56,7 @@ class Edalizer:
 
     @property
     def resolved_cores(self):
-        """ Get a list of all "used" cores after the dependency resolution """
+        """Get a list of all "used" cores after the dependency resolution"""
         try:
             return self.core_manager.get_depends(self.toplevel, self.flags)
         except DependencyError as e:
@@ -70,11 +70,11 @@ class Edalizer:
 
     @property
     def discovered_cores(self):
-        """ Get a list of all cores found by fusesoc """
+        """Get a list of all cores found by fusesoc"""
         return self.core_manager.db.find()
 
     def run(self):
-        """ Run all steps to create a EDAM file """
+        """Run all steps to create a EDAM file"""
 
         # Run the setup task on all cores (fetch and patch them as needed)
         self.setup_cores()
@@ -91,20 +91,20 @@ class Edalizer:
         return self.edam
 
     def _core_flags(self, core):
-        """ Get flags for a specific core """
+        """Get flags for a specific core"""
 
         core_flags = self.flags.copy()
         core_flags["is_toplevel"] = core.name == self.toplevel
         return core_flags
 
     def setup_cores(self):
-        """ Setup cores: fetch resources, patch them, etc. """
+        """Setup cores: fetch resources, patch them, etc."""
         for core in self.cores:
             logger.info("Preparing " + str(core.name))
             core.setup()
 
     def extract_generators(self):
-        """ Get all registered generators from the cores """
+        """Get all registered generators from the cores"""
         generators = {}
         for core in self.cores:
             logger.debug("Searching for generators in " + str(core.name))
@@ -117,7 +117,7 @@ class Edalizer:
         self.generators = generators
 
     def run_generators(self):
-        """ Run all generators """
+        """Run all generators"""
         self._resolved_or_generated_cores = []
         for core in self.cores:
             logger.debug("Running generators in " + str(core.name))

--- a/fusesoc/main.py
+++ b/fusesoc/main.py
@@ -445,7 +445,7 @@ def init_coremanager(config, args_cores_root):
     # Add libraries from config file, env var and command-line
     for library in config.libraries + args_libs:
         try:
-            cm.add_library(library)
+            cm.add_library(library, config.ignored_dirs)
         except (RuntimeError, OSError) as e:
             _s = "Failed to register library '{}'"
             logger.warning(_s.format(str(e)))

--- a/fusesoc/main.py
+++ b/fusesoc/main.py
@@ -126,15 +126,15 @@ def add_library(cm, args):
     library = Library(args.name, location, sync_type, sync_uri, auto_sync)
 
     if args.config:
-        config = Config(file=args.config)
+        config = Config(args.config)
     elif vars(args)["global"]:
         xdg_config_home = os.environ.get("XDG_CONFIG_HOME") or os.path.join(
             os.path.expanduser("~"), ".config"
         )
         config_file = os.path.join(xdg_config_home, "fusesoc", "fusesoc.conf")
-        config = Config(path=config_file)
+        config = Config(config_file)
     else:
-        config = Config(path="fusesoc.conf")
+        config = Config("fusesoc.conf")
 
     try:
         config.add_library(library)
@@ -472,9 +472,7 @@ def get_parser():
         default=[],
         action="append",
     )
-    parser.add_argument(
-        "--config", help="Specify the config file to use", type=argparse.FileType("r")
-    )
+    parser.add_argument("--config", help="Specify the config file to use")
     parser.add_argument(
         "--monochrome",
         help="Don't use color for messages",
@@ -678,7 +676,7 @@ def parse_args(argv):
 
 def fusesoc(args):
     init_logging(args.verbose, args.monochrome, args.log_file)
-    config = Config(file=args.config)
+    config = Config(args.config)
 
     cm = init_coremanager(config, args.cores_root)
     # Run the function

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -25,7 +25,7 @@ sync-uri = https://github.com/fusesoc/fusesoc-cores
 """
 
 
-def test_config_path():
+def test_config():
     tcf = tempfile.NamedTemporaryFile(mode="w+")
     tcf.write(
         EXAMPLE_CONFIG.format(
@@ -40,6 +40,25 @@ def test_config_path():
     conf = Config(tcf.name)
 
     assert conf.library_root == library_root
+
+
+def test_config_relative_path():
+    with tempfile.TemporaryDirectory() as td:
+        config_path = os.path.join(td, "fusesoc.conf")
+        with open(config_path, "w") as tcf:
+            tcf.write(
+                EXAMPLE_CONFIG.format(
+                    build_root="build_root",
+                    cache_root="cache_root",
+                    cores_root="cores_root",
+                    library_root="library_root",
+                )
+            )
+
+        conf = Config(tcf.name)
+        for name in ["build_root", "cache_root", "library_root"]:
+            abs_td = os.path.abspath(td)
+            assert getattr(conf, name) == os.path.join(abs_td, name)
 
 
 def test_config_libraries():

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -25,23 +25,6 @@ sync-uri = https://github.com/fusesoc/fusesoc-cores
 """
 
 
-def test_config_file():
-    tcf = tempfile.TemporaryFile(mode="w+")
-    tcf.write(
-        EXAMPLE_CONFIG.format(
-            build_root=build_root,
-            cache_root=cache_root,
-            cores_root=cores_root,
-            library_root=library_root,
-        )
-    )
-    tcf.seek(0)
-
-    conf = Config(file=tcf)
-
-    assert conf.build_root == build_root
-
-
 def test_config_path():
     tcf = tempfile.NamedTemporaryFile(mode="w+")
     tcf.write(
@@ -54,7 +37,7 @@ def test_config_path():
     )
     tcf.seek(0)
 
-    conf = Config(path=tcf.name)
+    conf = Config(tcf.name)
 
     assert conf.library_root == library_root
 
@@ -71,7 +54,7 @@ def test_config_libraries():
     )
     tcf.seek(0)
 
-    conf = Config(path=tcf.name)
+    conf = Config(tcf.name)
 
     lib = None
     for library in conf.libraries:

--- a/tests/test_coremanager.py
+++ b/tests/test_coremanager.py
@@ -21,7 +21,7 @@ def test_deptree(tmp_path):
     lib = Library("deptree", deptree_cores_dir)
 
     cm = CoreManager(Config())
-    cm.add_library(lib)
+    cm.add_library(lib, [])
 
     root_core = cm.get_core(Vlnv("::deptree-root"))
 
@@ -135,7 +135,7 @@ def test_copyto():
     lib = Library("misc", core_dir)
 
     cm = CoreManager(Config())
-    cm.add_library(lib)
+    cm.add_library(lib, [])
 
     core = cm.get_core(Vlnv("::copytocore"))
 
@@ -184,7 +184,7 @@ def test_export():
     core_dir = os.path.join(os.path.dirname(__file__), "cores")
 
     cm = CoreManager(Config())
-    cm.add_library(Library("cores", core_dir))
+    cm.add_library(Library("cores", core_dir), [])
 
     core = cm.get_core(Vlnv("::wb_intercon"))
 
@@ -230,7 +230,7 @@ def test_virtual():
     core_dir = os.path.join(os.path.dirname(__file__), "capi2_cores", "virtual")
 
     cm = CoreManager(Config())
-    cm.add_library(Library("virtual", core_dir))
+    cm.add_library(Library("virtual", core_dir), [])
 
     root_core = cm.get_core(Vlnv("::user"))
 

--- a/tests/test_edalizer.py
+++ b/tests/test_edalizer.py
@@ -19,7 +19,7 @@ def test_generators():
     lib = Library("edalizer", cores_dir)
 
     cm = CoreManager(Config())
-    cm.add_library(lib)
+    cm.add_library(lib, [])
 
     core = cm.get_core(Vlnv("::generate"))
 

--- a/tests/test_ignored_dirs.py
+++ b/tests/test_ignored_dirs.py
@@ -1,0 +1,52 @@
+# Copyright FuseSoC contributors
+# Licensed under the 2-Clause BSD License, see LICENSE for details.
+# SPDX-License-Identifier: BSD-2-Clause
+
+import os
+import tempfile
+
+from fusesoc.config import Config
+from fusesoc.main import init_coremanager
+
+build_root = "test_build_root"
+
+EXAMPLE_CONFIG = """
+[main]
+ignored_dirs = B nonexistent_dir
+"""
+
+EXAMPLE_CORE = """\
+CAPI=2:
+description: dummy core
+name: ::dummy:{version}
+"""
+
+
+def test_ignored_dirs():
+    """Check that ignored_dirs works in config files."""
+    with tempfile.TemporaryDirectory() as td:
+        for dirname, version in [("A", "1.0"), ("B", "2.0")]:
+            dir_path = os.path.join(td, dirname)
+            core_path = os.path.join(dir_path, "foo.core")
+
+            os.mkdir(dir_path)
+            with open(core_path, "w") as core_file:
+                core_file.write(EXAMPLE_CORE.format(version=version))
+
+        conf_path0 = os.path.join(td, "0.conf")
+        with open(conf_path0, "w") as conf_file0:
+            conf_file0.write("")
+
+        conf_path1 = os.path.join(td, "1.conf")
+        with open(conf_path1, "w") as conf_file1:
+            conf_file1.write(EXAMPLE_CONFIG)
+
+        conf0 = Config(conf_path0)
+        assert len(conf0.ignored_dirs) == 0
+        cm0 = init_coremanager(conf0, [td])
+        assert len(cm0.get_cores()) == 2
+
+        conf1 = Config(conf_path1)
+        assert len(conf1.ignored_dirs) == 2
+        cm1 = init_coremanager(conf1, [td])
+        assert len(cm1.get_cores()) == 1


### PR DESCRIPTION
The first 3 commits in this PR are minor cleanups. The most interesting (controversial?) bit is probably the first:

- **Bump to a working version of Black**: Although we've pinned Black to version 20.8b1, this doesn't pin the "click" library on which it depends. Bump Black to a version that works with the latest click.

After that, I made a couple of tidy-up commits in `config.py`. Then this commit might need a bit of thought:

- **Interpret relative paths in config file relative to it, not CWD**: This changes behaviour, but probably to something more useful than what we had before. I'd be very surprised if we had any users relying on the fact that relative paths in a config file were interpreted relative to CWD.

Finally, we can add the `ignored_dirs` key that motivated the whole thing.