### PR TITLE
Adding support for no_export flag

### DIFF
--- a/fusesoc/capi2/core.py
+++ b/fusesoc/capi2/core.py
@@ -301,6 +301,8 @@ class Core:
             # Special case for tool as we get it from default_tool
             if target.default_tool:
                 flags["tool"] = str(target.default_tool)
+            if target.no_export:
+                flags["no_export"] = target.no_export
         return flags
 
     def get_scripts(self, files_root, flags):
@@ -782,6 +784,9 @@ Target:
     - name : toplevel
       type : StringWithUseFlagsOrList
       desc : Top-level module. Normally a single module/entity but can be a list of several items
+    - name : no_export
+      type : String
+      desc : Same behaviour as ``--no-export`` command line argument. Value should be *true* or *false*.
   lists:
     - name : filesets
       type : StringWithUseFlags

--- a/fusesoc/main.py
+++ b/fusesoc/main.py
@@ -331,19 +331,24 @@ def run_backend(
     if not tool:
         logger.error(tool_error.format(system))
         exit(1)
+
     build_root = build_root_arg or os.path.join(
         cm.config.build_root, core.name.sanitized_name
     )
     logger.debug(f"Setting build_root to {build_root}")
-    if export:
+
+    no_export = flags.get("no_export", False)
+    if export and not no_export:
         export_root = os.path.join(build_root, "src")
     else:
         export_root = None
+
     try:
         work_root = os.path.join(build_root, f"{target}-{tool}")
     except SyntaxError as e:
         logger.error(e.msg)
         exit(1)
+
     edam_file = os.path.join(work_root, core.name.sanitized_name + ".eda.yml")
     if not os.path.exists(edam_file):
         do_configure = True


### PR DESCRIPTION
This change adds support for setting a no_export flag from within a target which
prevents the source files from being exported to the build tree.  You can
currently get the same behaviour by passing the --no-export command line argument
but this relies on the user remembering to set it.

The use case is for flows that would break if the files were copied to the build
tree, such as linting where the waivers reference absolute paths.