### PR TITLE
Make sure shallow clone pulls all tags

### DIFF
--- a/fusesoc/provider/git.py
+++ b/fusesoc/provider/git.py
@@ -37,7 +37,7 @@ class Git(Provider):
         # TODO : Sanitize URL
         repo = self.config.get("repo")
         logger.info("Checking out " + repo + " to " + local_dir)
-        args = ["clone", "-q", "--depth", "1", repo, local_dir]
+        args = ["clone", "-q", "--depth", "1", "--no-single-branch", repo, local_dir]
         Launcher("git", args).run()
         if version:
             args = ["-C", local_dir, "checkout", "-q", version]


### PR DESCRIPTION
No-single-branch flag ensures shallow-clone depth constraint does not make older tags invisible

(Issue #576)