### PR TITLE
Fall back if shallow clones fail

### DIFF
--- a/fusesoc/provider/git.py
+++ b/fusesoc/provider/git.py
@@ -37,8 +37,12 @@ class Git(Provider):
         # TODO : Sanitize URL
         repo = self.config.get("repo")
         logger.info("Checking out " + repo + " to " + local_dir)
-        args = ["clone", "-q", "--depth", "1", "--no-single-branch", repo, local_dir]
-        Launcher("git", args).run()
+        try:
+            args = ["clone", "-q", "--depth", "1", "--no-single-branch", repo, local_dir]
+            Launcher("git", args).run()
+        except:
+            args = ["clone", "-q", "--no-single-branch", repo, local_dir]
+            Launcher("git", args).run()
         if version:
             args = ["-C", local_dir, "checkout", "-q", version]
             Launcher("git", args).run()

--- a/fusesoc/provider/git.py
+++ b/fusesoc/provider/git.py
@@ -40,9 +40,12 @@ class Git(Provider):
         try:
             args = ["clone", "-q", "--depth", "1", "--no-single-branch", repo, local_dir]
             Launcher("git", args).run()
-        except:
-            args = ["clone", "-q", "--no-single-branch", repo, local_dir]
-            Launcher("git", args).run()
+        except RuntimeError as e:
+            try:
+                args = ["clone", "-q", "--no-single-branch", repo, local_dir]
+                Launcher("git", args).run()
+            except:
+                raise e
         if version:
             args = ["-C", local_dir, "checkout", "-q", version]
             Launcher("git", args).run()


### PR DESCRIPTION
If an attempt to shallow clone a git repo fails, try a non-shallow clone, as this feature is not supported by all remotes.

fixes #606 