### PR TITLE
Adding support for no_export flag.

### DIFF
--- a/fusesoc/main.py
+++ b/fusesoc/main.py
@@ -367,7 +367,7 @@ def run_backend(
         work_root = os.path.join(build_root, f"{target}-{tool}")
     logger.debug(f"Setting work_root to {work_root}")
 
-    if export:
+    if export and not "no_export" in flags.keys():
         export_root = os.path.join(work_root, "src")
         logger.debug(f"Setting export_root to {export_root}")
     else:


### PR DESCRIPTION
Replicate --no-export command line argument using flags. This is useful for tool flows such as filelist generation where you don't want to copy all source files to the Fusesoc build directory.