### PR TITLE
Allow double quotes in string expressions

### DIFF
--- a/fusesoc/capi2/exprs.py
+++ b/fusesoc/capi2/exprs.py
@@ -12,7 +12,7 @@ FuseSoC core files allow strings matching the following pseudo-BNF:
   expr ::= word
          | conditional
 
-  word ::= [a-zA-Z0-9:<>.\[\]_-,=~/^+]+    (one or more alphanum/special chars)
+  word ::= [a-zA-Z0-9:<>.\[\]_-,=~/^+"]+    (one or more alphanum/special chars)
 
   conditional ::= condition "?" "(" exprs ")"
 
@@ -75,7 +75,7 @@ def _get_parser():
     if _PARSER is not None:
         return _PARSER
 
-    word = Word(alphanums + "`:<>.[]_-,=~/^+")
+    word = Word(alphanums + '`:<>.[]_-,=~/^+"')
     exprs = Forward()
 
     conditional = (

--- a/tests/test_exprs.py
+++ b/tests/test_exprs.py
@@ -26,6 +26,7 @@ def test_exprs():
     check_parses_to("a ? (b ? (c))", [(False, "a", [(False, "b", ["c"])])])
     check_parses_to("!a ? (b)", [(True, "a", ["b"])])
     check_parses_to("a b ? (c)", ["a", (False, "b", ["c"])])
+    check_parses_to('a"b"', ['a"b"'])
 
     check_parse_error("!a")
     check_parse_error("a ? b")


### PR DESCRIPTION
Passing tool arguments such as -CFLAGS "blah blah" requires '"'.