### PR TITLE
Modified yaml_fwrite to preserve file insertion order

### DIFF
--- a/fusesoc/utils.py
+++ b/fusesoc/utils.py
@@ -151,7 +151,7 @@ def setup_logging(level, monchrome=False, log_file=None):
 def yaml_fwrite(filepath, content, preamble=""):
     with open(filepath, "w") as f:
         f.write(preamble)
-        f.write(yaml.dump(content, Dumper=YamlDumper))
+        f.write(yaml.dump(content, Dumper=YamlDumper, sort_keys=False))
 
 
 def yaml_fread(filepath, resolve_env_vars=False):


### PR DESCRIPTION
Added `sort_keys=False` to `yaml.dump` call in `yaml_fwrite` to preserve the order of insertion of the files to be written in the .core when writing a generator (for instance for packages to be included and compiled before other sources). Supported from PyYAML >= 5.1.