### PR TITLE
fix missing workdir when no_export

### DIFF
--- a/fusesoc/main.py
+++ b/fusesoc/main.py
@@ -375,6 +375,7 @@ def run_backend(
         logger.debug(f"Setting export_root to {export_root}")
     else:
         export_root = None
+        os.system(f"mkdir -p {work_root}")
 
     backend_class = None
     if flow:


### PR DESCRIPTION
Fixes a bug
When using no_export, there is an error when creating edalizer yaml

Traceback (most recent call last):
  File "/home/skok/.local/bin/fusesoc", line 11, in <module>
    load_entry_point('fusesoc', 'console_scripts', 'fusesoc')()
  File "/home/skok/pkgs/fusesoc/fusesoc/main.py", line 746, in main
    fusesoc(args)
  File "/home/skok/pkgs/fusesoc/fusesoc/main.py", line 736, in fusesoc
    args.func(cm, args)
  File "/home/skok/pkgs/fusesoc/fusesoc/main.py", line 293, in run
    run_backend(
  File "/home/skok/pkgs/fusesoc/fusesoc/main.py", line 427, in run_backend
    edalizer.to_yaml(edam_file)
  File "/home/skok/pkgs/fusesoc/fusesoc/edalizer.py", line 507, in to_yaml
    return utils.yaml_fwrite(edam_file, self.edam)
  File "/home/skok/pkgs/fusesoc/fusesoc/utils.py", line 152, in yaml_fwrite
    with open(filepath, "w") as f:

simply fixed with a mkdir when no_export flag is given
