### PR TITLE
Add a provider for libraries in environmental folders

### DIFF
--- a/fusesoc/config.py
+++ b/fusesoc/config.py
@@ -282,7 +282,10 @@ class Config:
 
         self._cp.add_section(section_name)
 
-        self._cp.set(section_name, "location", library.location)
+        # Libraries in special environmental folders may not have a fixed location, but
+        # if they aren't set up to auto-sync they should
+        if library.sync_type not in ["env"] or not library.auto_sync:
+            self._cp.set(section_name, "location", library.location)
 
         if library.sync_type:
             self._cp.set(section_name, "sync-uri", library.sync_uri)

--- a/fusesoc/config.py
+++ b/fusesoc/config.py
@@ -265,7 +265,6 @@ class Config:
         from fusesoc.provider import get_provider
 
         section_name = "library." + library.name
-
         if section_name in self._cp.sections():
             logger.warning(
                 "Not adding library. {} already exists in configuration file".format(
@@ -273,6 +272,13 @@ class Config:
                 )
             )
             return
+
+        try:
+            provider = get_provider(library.sync_type)
+        except ImportError:
+            raise RuntimeError("Invalid sync-type '{}'".format(library["sync-type"]))
+
+        provider.init_library(library)
 
         self._cp.add_section(section_name)
 
@@ -287,12 +293,5 @@ class Config:
             self._cp.set(section_name, "sync-type", library.sync_type)
             _auto_sync = "true" if library.auto_sync else "false"
             self._cp.set(section_name, "auto-sync", _auto_sync)
-
-        try:
-            provider = get_provider(library.sync_type)
-        except ImportError:
-            raise RuntimeError("Invalid sync-type '{}'".format(library["sync-type"]))
-
-        provider.init_library(library)
 
         self.write()

--- a/fusesoc/coremanager.py
+++ b/fusesoc/coremanager.py
@@ -221,7 +221,14 @@ class CoreManager:
 
     def find_cores(self, library, ignored_dirs):
         found_cores = []
+
+        # Resolve any environmentally-special library locations
         path = os.path.expanduser(library.location)
+        if library.sync_type in ["env"]:
+            from fusesoc.provider import get_provider
+
+            path = get_provider(library.sync_type).resolve(library)
+
         exclude = {".git"}
         if os.path.isdir(path) == False:
             raise OSError(path + " is not a directory")

--- a/fusesoc/librarymanager.py
+++ b/fusesoc/librarymanager.py
@@ -20,7 +20,7 @@ class Library:
         sync_version=None,
         auto_sync=True,
     ):
-        if sync_type and not sync_type in ["local", "git"]:
+        if sync_type and not sync_type in ["local", "git", "env"]:
             raise ValueError(
                 "Library {} ({}) Invalid sync-type '{}'".format(
                     name, location, sync_type
@@ -46,8 +46,8 @@ class Library:
         def l(s):
             return self.name + " : " + s
 
-        if self.sync_type == "local":
-            logger.info(l("sync-type is local. Ignoring update"))
+        if self.sync_type in ["local", "env"]:
+            logger.info(l(f"sync-type is {self.sync_type}. Ignoring update"))
             return
 
         # FIXME: Do an initial checkout if missing

--- a/fusesoc/main.py
+++ b/fusesoc/main.py
@@ -500,7 +500,7 @@ def get_parser():
     parser_library_add.add_argument(
         "--sync-type",
         help="The provider type for the library. Defaults to 'git'.",
-        choices=["git", "local"],
+        choices=["git", "local", "env"],
         dest="sync-type",
     )
     parser_library_add.add_argument(

--- a/fusesoc/provider/env.py
+++ b/fusesoc/provider/env.py
@@ -1,0 +1,76 @@
+# Copyright FuseSoC contributors
+# Licensed under the 2-Clause BSD License, see LICENSE for details.
+# SPDX-License-Identifier: BSD-2-Clause
+
+import logging
+import subprocess
+from typing import Callable
+
+from fusesoc.librarymanager import Library
+from fusesoc.provider.provider import Provider
+from fusesoc.utils import Launcher
+
+logger = logging.getLogger(__name__)
+
+
+class Env(Provider):
+    """A provider for cores in locations special to the environment."""
+
+    def _resolve_poetry(library: Library) -> str:
+        logger.info(f"Looking for Poetry environment for library {library.name}")
+
+        err = False
+        envpath = None
+        try:
+            # We need to wrap Poetry in Poetry in case the environment uses a different
+            # Python interpreter than is currently configured through `poetry env use`. If
+            # the two differ, then `poetry env info -p` just gives us a blank path.
+            proc = Launcher("poetry", ["run", "poetry", "env", "info", "--path"])
+            proc = proc.run(stdout=subprocess.PIPE)
+            stdout, _ = proc.communicate()
+            envpath = stdout.decode("ascii").strip()
+        except subprocess.CalledProcessError as e:
+            logger.error("Failed to run `poetry env info`")
+            err = True
+
+        if envpath and len(envpath) == 0:
+            logger.error("Poetry returned an empty environment path")
+            err = True
+
+        if err:
+            raise RuntimeError("Could not create library from Poetry environment")
+
+        logger.info(f"Using '{envpath}'")
+        return envpath
+
+    _SYNC_URIS = {"poetry": _resolve_poetry}
+
+    @staticmethod
+    def resolve(library: Library) -> str:
+        resolver = Env._SYNC_URIS.get(library.sync_uri, None)
+        if not resolver:
+            raise RuntimeError(
+                "Unsupported sync-uri '{}' for sync-type 'env', options are: {}".format(
+                    library.sync_uri, Env._SYNC_URIS.keys()
+                )
+            )
+
+        return resolver(library)
+
+    @staticmethod
+    def init_library(library):
+        path = Env.resolve(library)
+
+        library.location = None
+        if not library.auto_sync:
+            logger.info("Auto-sync disabled, converting to local provider")
+            library.location = path
+            library.sync_type = "local"
+            library.sync_uri = path
+
+    def _checkout(self, local_dir):
+        pass
+
+    @staticmethod
+    def update_library(library):
+        pass

--- a/fusesoc/utils.py
+++ b/fusesoc/utils.py
@@ -6,6 +6,7 @@ import logging
 import subprocess
 import sys
 import warnings
+from typing import Any
 
 import yaml
 
@@ -25,15 +26,20 @@ class Launcher:
         self.args = args
         self.cwd = cwd
 
-    def run(self):
+    def run(self, **kwargs) -> subprocess.Popen:
         """Runs the cmd with args after converting them all to strings via str"""
         logger.debug(self.cwd or "./")
         logger.debug("    " + str(self))
+
+        cmd = map(str, [self.cmd] + self.args)
         try:
-            subprocess.check_call(
-                map(str, [self.cmd] + self.args),
-                cwd=self.cwd,
-            ),
+            proc = subprocess.Popen(args=cmd, cwd=self.cwd, **kwargs)
+            proc.wait()
+
+            if proc.returncode != 0:
+                raise subprocess.CalledProcessError(proc.returncode, cmd)
+
+            return proc
         except FileNotFoundError:
             raise RuntimeError(
                 "Command '" + self.cmd + "' not found. Make sure it is in $PATH"


### PR DESCRIPTION
### Overview

The main addition in this PR is `fusesoc.providers.env.Env`, which is meant to represent a library in a (not necessarily fixed) location in the environment. Specifically, included in this PR is a provider for [Poetry] that looks for the virtual environment set up by Poetry and adds it as a searchable location. An example `fusesoc.conf` would be:

```ini
[library.my-venv]
sync-type = env
sync-uri = poetry
auto-sync = true
```

This would invoke Poetry to find the active virtual environment each time it's needed. This would be added to the configuration with the command `fusesoc library add --sync-type env my-venv poetry`.

This provider can also be used to automatically produce a `local` provider by passing `--no-auto-sync`.

I've tried to make this general enough that it's straightforward to add other targets that follow the general theme of:
 - Probably created automatically
 - Exists locally (or somewhere that can be treated as locally)
 - Has a location that can be queried automatically

The main intention here is to make it easier to distribute FuseSoC cores (or bundles of cores) through a Python package manager.

[Poetry]: https://python-poetry.org/

### Related changes

As well as that main change, this PR includes the following related changes that support this new provider:

 - In `fusesoc.config.add_library`, the call to `init_library` is moved to before the updates to the `fusesoc.conf` file to allow the new provider to check that it can resolve the environmental folder and to allow it to provide a resolved location if needed

 - In `fusesoc.utils.Launcher`, the `Launcher.run` method is adjusted to return a `subprocess.Popen` and to accept `**kwargs` (but otherwise should be compatible), which allows the `Env` provider to capture output from its invocation of Poetry

 - In `fusesoc.coremanager.find_cores`, a call to `Env.resolve` is added before directory walking takes place; this lets us avoid having the concrete location in `fusesoc.conf` as explicitly these types of folders may not have a fixed location