### PR TITLE
Prepending generated core files

### DIFF
--- a/fusesoc/capi2/json_schema.py
+++ b/fusesoc/capi2/json_schema.py
@@ -289,9 +289,9 @@ capi2_schema = """
               "type": "string"
             },
             "position": {
-              "description": "Where to insert the generated core. Legal values are *first*, *append* or *last*. *append* will insert core after the core that called the generator",
+              "description": "Where to insert the generated core. Legal values are *first*, *prepend*, *append* or *last*. *prepend* (*append*) will insert core before (after) the core that called the generator",
               "type": "string",
-              "pattern": "^first|append|last$"
+              "pattern": "^first|prepend|append|last$"
             },
             "parameters": {
               "description": "Generator-specific parameters. ``fusesoc gen show $generator`` might show available parameters. ",

--- a/fusesoc/edalizer.py
+++ b/fusesoc/edalizer.py
@@ -272,6 +272,8 @@ class Edalizer:
                     first_snippets.append(snippet)
                 elif core.pos == "last":
                     last_snippets.append(snippet)
+                elif core.pos == "prepend" and len(snippets) > 0:
+                    snippets.insert(len(snippets)-1, snippet)
                 else:
                     snippets.append(snippet)
             else:


### PR DESCRIPTION
This merge request allows to prepend generated core files right before the core that instantiates a generator. 

Use-case: ModelSim requires vhdl files to be built in the right order. Imagine you generate a vhdl file (e.g. package with settings) and you want to use it already in the parent core. Using "first" position does not work if the package itself depends on some other package (core). 
Here is the example dependency tree, to make things clear:
common_core <- generated_core (depends on  common_core) <- current_core (has common_core in dependencies, instantiates generator to produce generated_core). 
If using "first" keyword, it would appear in the following order "generated_core <- common_core <- current_core" - which will not work. 

