### PR TITLE
Enable windows tests again, the first steps (#528)

### DIFF
--- a/fusesoc/config.py
+++ b/fusesoc/config.py
@@ -6,6 +6,7 @@ import configparser
 import logging
 import os
 from configparser import ConfigParser as CP
+from pathlib import Path
 
 from fusesoc.librarymanager import Library
 
@@ -24,12 +25,13 @@ class Config:
             )
             config_files = [
                 "/etc/fusesoc/fusesoc.conf",
-                os.path.join(xdg_config_home, "fusesoc", "fusesoc.conf"),
+                str(Path(xdg_config_home) / "fusesoc" / "fusesoc.conf"),
                 "fusesoc.conf",
             ]
         else:
             logger.debug(f"Using config file '{path}'")
             if not os.path.isfile(path):
+                Path(path).parent.mkdir(parents=True, exist_ok=True)
                 with open(path, "a"):
                     pass
             config_files = [path]
@@ -127,7 +129,7 @@ class Config:
         xdg_cache_home = os.environ.get("XDG_CACHE_HOME") or os.path.join(
             os.path.expanduser("~"), ".cache"
         )
-        return os.path.join(xdg_cache_home, "fusesoc")
+        return str(Path(xdg_cache_home) / "fusesoc")
 
     def _get_library_root(self):
         from_cfg = self._path_from_cfg("library_root")
@@ -137,7 +139,7 @@ class Config:
         xdg_data_home = os.environ.get("XDG_DATA_HOME") or os.path.join(
             os.path.expanduser("~"), ".local/share"
         )
-        return os.path.join(xdg_data_home, "fusesoc")
+        return str(Path(xdg_data_home) / "fusesoc")
 
     def _get_ignored_dirs(self):
         return self._paths_from_cfg("ignored_dirs")

--- a/fusesoc/main.py
+++ b/fusesoc/main.py
@@ -7,9 +7,9 @@ import argparse
 import os
 import shutil
 import signal
-import subprocess
 import sys
 import warnings
+from pathlib import Path
 
 from fusesoc import __version__
 
@@ -97,9 +97,7 @@ def add_library(fs, args):
     if args.config:
         config = Config(args.config)
     elif vars(args)["global"]:
-        xdg_config_home = os.environ.get("XDG_CONFIG_HOME") or os.path.join(
-            os.path.expanduser("~"), ".config"
-        )
+        xdg_config_home = Path(os.getenv("XDG_CONFIG_HOME", Path.home() / ".config"))
         config_file = os.path.join(xdg_config_home, "fusesoc", "fusesoc.conf")
         config = Config(config_file)
     else:
@@ -331,7 +329,6 @@ def run(fs, args):
 
 
 def config(fs, args):
-
     conf = Config(path=args.config if args.config else None)
 
     if not hasattr(conf, args.key):
@@ -604,7 +601,6 @@ def parse_args(argv):
 
 
 def args_to_config(args, config):
-
     if hasattr(args, "resolve_env_vars_early") and args.resolve_env_vars_early:
         setattr(config, "args_resolve_env_vars_early", args.resolve_env_vars_early)
 

--- a/tox.ini
+++ b/tox.ini
@@ -13,8 +13,8 @@ deps =
 # directory, but creates an isolated home directory within the tox working
 # directory, and clears it out after each test.
 commands =
-    /bin/rm -rf {toxworkdir}/.tmp/homedir/.cache {toxworkdir}/.tmp/homedir/.local/share {toxworkdir}/.tmp/homedir/.config
-    mkdir -p {toxworkdir}/.tmp/homedir/.config/fusesoc
+    python -c "import os, shutil, pathlib, uuid; path = pathlib.Path(os.environ['XDG_CACHE_HOME']).parent; path.exists() or exit(); new = path.rename(path.parent / str(uuid.uuid4())); shutil.rmtree(str(new), ignore_errors=True)"
+
     fusesoc --verbose library add --global fusesoc_cores https://github.com/fusesoc/fusesoc-cores
     fusesoc list-cores
     fusesoc library update
@@ -29,9 +29,6 @@ setenv =
 passenv =
     GITHUB_ACTIONS
 
-allowlist_externals =
-  /bin/rm
-  mkdir
 
 [testenv:doc]
 # Note: this target is *not* used by ReadTheDocs, which runs sphinx-build


### PR DESCRIPTION
To allow for the CI to run the windows tests again, I've done the bare minimum to get the tox test runner to run again under Windows. There are failing tests but, the purpose of this pull request is just to make it run again.

* Resolve XDG paths in a OS independent way (using `pathlib.Path` to do all `\` and `/` convertions)
* Create directories for config file if they doesn't exist. 
* Workaround for removal of `tmp` XDG files on windows. *`shutil.rmtree` sometimes fails one windows, seems to be UAC related.*

Needs to run on the CI for Linux verdict just tested for python versions 3{6-11} on windows 11 😄 