### PR TITLE
Add core filename to output of `fusesoc core show`.

### DIFF
--- a/fusesoc/capi2/core.py
+++ b/fusesoc/capi2/core.py
@@ -33,8 +33,7 @@ class Core:
 
         self.cache_root = cache_root
 
-        basename = os.path.basename(self.core_file)
-
+        self.core_basename = os.path.basename(self.core_file)
         self.core_root = os.path.dirname(self.core_file)
 
         # Populated by CoreDB._solve(). TODO: Find a better solution for that.
@@ -516,6 +515,7 @@ class Core:
 Name:        {}
 Description: {}
 Core root:   {}
+Core file:   {}
 
 Targets:
 {}"""
@@ -539,6 +539,7 @@ Targets:
             str(self.name),
             str(self.get_description() or "<No description>"),
             str(self.core_root),
+            str(self.core_basename),
             targets,
         )
 

--- a/tests/test_capi2.py
+++ b/tests/test_capi2.py
@@ -635,7 +635,11 @@ def test_capi2_info():
         core = Core(Core2Parser(), core_file)
 
         gen_info = "\n".join(
-            [x for x in core.info().split("\n") if not "Core root" in x]
+            [
+                x
+                for x in core.info().split("\n")
+                if not any([y in x for y in ["Core root", "Core file"]])
+            ]
         )
         with open(os.path.join(tests_dir, __name__, core_name + ".info")) as f:
             assert f.read() == gen_info, core_name


### PR DESCRIPTION
This commit updates the output of `fusesoc core show` to add the filename of the core file itself. This change is required for tools such as the filelist Edalize backend as discussed in
https://github.com/olofk/edalize/issues/25.

The output of `fusesoc core show` now looks like:

CORE INFO
Name:        vee:el:en:vee
Description: Top bombing
Core root:   /root/path/to/core/file
Core file:   basename.core