### PR TITLE
Fixed setup dependency versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -52,12 +52,12 @@ setup(
     ],
     install_requires=[
         "edalize>=0.4.1",
-        "pyparsing",
-        "pyyaml",
+        "pyparsing>=2.3.1",
+        "pyyaml>=6.0",
         "simplesat>=0.8.0",
         "fastjsonschema",
         "jsonschema2md",
-        "myst_parser",
+        "myst_parser>=0.18.0",
     ],
     # Supported Python versions: 3.6+
     python_requires=">=3.6, <4",


### PR DESCRIPTION
I tested FuseSoC with all versions of pyparsing, pyyaml, fastjsonschema, jsonschema2md, and myst_parser. I found and added the minimum required versions. (fastjsonschema and jsonschema2md can be any version)

This fixes a setup issue I was having