### PR TITLE
Improved inheritance

### DIFF
--- a/fusesoc/capi2/inheritance.py
+++ b/fusesoc/capi2/inheritance.py
@@ -1,0 +1,39 @@
+# Copyright FuseSoC contributors
+# Licensed under the 2-Clause BSD License, see LICENSE for details.
+# SPDX-License-Identifier: BSD-2-Clause
+
+import copy
+import re
+
+from fusesoc import utils
+
+
+class Inheritance:
+    MERGE_OPERATOR = "<<__FUSESOC_MERGE_OVERLOAD__<<"
+
+    def yaml_merge_2_fusesoc_merge(capi):
+        """
+        Replace YAML merge key operator (<<) with FuseSoC merge operator
+        """
+        yaml_merge_pattern = (
+            r"((?:\n|{|\{\s*(?:[^{}]*\{[^{}]*\})*[^{}]*\},)\s*)<<(?=\s*:)"
+        )
+        while re.search(yaml_merge_pattern, capi):
+            capi = re.sub(yaml_merge_pattern, r"\1" + Inheritance.MERGE_OPERATOR, capi)
+        return capi
+
+    def elaborate_inheritance(capi):
+        if not isinstance(capi, dict):
+            return capi
+
+        for key, value in capi.items():
+            if isinstance(value, dict):
+                capi[key] = Inheritance.elaborate_inheritance(copy.deepcopy(value))
+
+        parent = capi.pop(Inheritance.MERGE_OPERATOR, {})
+        if isinstance(parent, dict):
+            capi = utils.merge_dict(parent, capi, concat_list_appends_only=True)
+        else:
+            raise SyntaxError("Invalid use of inheritance operator")
+
+        return capi

--- a/tests/capi2_cores/parser/inheritance.core
+++ b/tests/capi2_cores/parser/inheritance.core
@@ -1,0 +1,59 @@
+CAPI=2:
+# Copyright FuseSoC contributors
+# Licensed under the 2-Clause BSD License, see LICENSE for details.
+# SPDX-License-Identifier: BSD-2-Clause
+
+name: ::inheritance:0
+filesets:
+  fileset_a:
+    files:
+      - 1.txt
+      - 2.txt
+      - 3.txt
+  fileset_b:
+    files:
+      - 4.txt
+      - 5.txt
+      - 6.txt
+  fileset_c:
+    files:
+      - 7.txt
+      - 8.txt
+      - 9.txt
+
+targets:
+  default: &default
+    filesets:
+      - fileset_a
+  child: &child
+    <<: *default
+    filesets_append:
+      - fileset_b
+  grandchild: &grandchild
+    <<: *child
+    filesets_append:
+      - fileset_c
+  child2: &child2
+    <<: *default
+    filesets:
+      - fileset_b
+    filesets_append:
+      - fileset_c
+
+  subfield: &subfield
+    tools:
+      verilator:
+        mode: cc
+        verilator_options:
+          - --timing
+  subfield_child:
+    <<: *subfield
+    tools:
+      verilator:
+        mode: lint-only
+
+  merge_test1: {<<: *default}
+  merge_test2<<: {tools: {2<<: {}}}
+  <<merge_test3: {tools: {<<3: {}}}
+  merge_test4: {tools: {t4: {t44: <<4, <<: *default}}, <<: *default}
+  merge_test5: {<<__FUSESOC_MERGE_OVERLOAD__<<: *default}


### PR DESCRIPTION
Fixes #639 and fixes #624

In summary, inheritance is no longer implemented by PyYAML's merge key implementation. Instead, it is overridden by a custom FuseSoC implementation

## Specifics

* Added [fusesoc/capi2/inheritance.py](https://github.com/sifferman/fusesoc/blob/9af5a0ef42d96a8761090cc0b5abbe0c379340da/fusesoc/capi2/inheritance.py) to centralize logic related to inheritance

* `utils.yaml_fread()` now calls `utils.yaml_read()` to improve code reusability

* <ins>**Possibly**</ins> fixed small bug in `utils.yaml_read()` by changing `data.read()` to `data`. (There is no test in the CI that checks for this case, so I am uncertain whether this change is good)

* `utils.yaml_read()` now replaces all merge key operators (`<<`) with an intermediate value of `Inheritance.MERGE_OPERATOR`, then turns the YAML into a dictionary as usual, then runs the new `Inheritance.elaborate_inheritance()` function that matches the specifications in #639 

* Gave `utils.merge_dict()` the flag `concat_list_appends_only` that, when set to `True`, will only concatenate arrays that end in `"_append"`. Usually `utils.merge_dict()` will concatenate all arrays