### PR TITLE
Allow Python to choose generator interpreter using shutil parameter t…

### DIFF
--- a/fusesoc/capi2/json_schema.py
+++ b/fusesoc/capi2/json_schema.py
@@ -317,7 +317,7 @@ capi2_schema = """
               "type": "string"
             },
             "interpreter": {
-              "description": "If the command needs a custom interpreter (such as python) this will be inserted as the first argument before command when calling the generator. The interpreter needs to be on the system PATH.",
+              "description": "If the command needs a custom interpreter (such as python) this will be inserted as the first argument before command when calling the generator. The interpreter needs to be on the system PATH; specifically, shutil.which needs to be able to find the interpreter).",
               "type": "string"
             },
             "cache_type": {

--- a/fusesoc/edalizer.py
+++ b/fusesoc/edalizer.py
@@ -521,6 +521,7 @@ class Ttptttg:
         self.generator = generators[generator_name]
         self.name = ttptttg["name"]
         self.pos = ttptttg["pos"]
+        self.gen_name = generator_name
         self.gen_root = gen_root
         self.resolve_env_vars = resolve_env_vars
         parameters = ttptttg["config"]
@@ -601,7 +602,14 @@ class Ttptttg:
         ]
 
         if "interpreter" in self.generator:
-            args[0:0] = [self.generator["interpreter"]]
+            interp = self.generator["interpreter"]
+            interppath = shutil.which(interp)
+            if not interppath:
+                raise RuntimeError(
+                    f"Could not find generator interpreter '{interp}' using shutil.which.\n"
+                    f"Interpreter requested by generator {self.gen_name}, requested by core {self.core}.\n"
+                )
+            args[0:0] = [interppath]
 
         Launcher(args[0], args[1:], cwd=generator_cwd).run()
 


### PR DESCRIPTION
…o generators.

Rationale is that I was running fusesoc from a virtual environment on Windows, and needed `fusesoc` to call `python` to generate a core for me.

Unfortunately, due to some [wonderful](https://bugs.python.org/issue24793) design choices in Windows that I don't really understand, _even with the `PATH` correctly set_ in the virtual environment, `fusesoc` was invoking my system `python`, instead of the virtual environment one. This caused my generators using [a new amaranth feature](https://github.com/amaranth-lang/amaranth/pull/904) to fail because I don't have the corresponding commits on the `amaranth` installed on my system (and checking out that version and `pip install -e .` just papers over what I think is a path search issue).

`shutil` is also apparently the appropriate way to work around path issues like mine. See the warning in the [`Popen` constructor](https://docs.python.org/3/library/subprocess.html#popen-constructor).