### PR TITLE
Add parameter indicating if files are exported

### DIFF
--- a/fusesoc/edalizer.py
+++ b/fusesoc/edalizer.py
@@ -288,6 +288,7 @@ class Edalizer:
             "tool_options": {},
             "toplevel": top_core.get_toplevel(self.flags),
             "vpi": [],
+            "export_files": self.export_root is not None,
         }
 
         for snippet in first_snippets + snippets + last_snippets:


### PR DESCRIPTION
This parameter is used for a PR to [enable the --no-export flag for Libero](https://github.com/olofk/edalize/pull/398). Libero's `import_file` command always copies the file into the local project directory, so the project script needs a way to tell if it should link instead using `create_link`.