### PR TITLE
"tool list' CLI argument now functional

### DIFF
--- a/fusesoc/main.py
+++ b/fusesoc/main.py
@@ -200,7 +200,7 @@ def list_cores(fs, args):
 
 
 def list_tools(fs, args):
-    from edalize.edatool import walk_tool_packages
+    from edalize.edatool import get_edatool, walk_tool_packages
 
     _tp = list(walk_tool_packages())
     maxlen = max(map(len, _tp))

--- a/tests/test_coremanager.py
+++ b/tests/test_coremanager.py
@@ -215,9 +215,11 @@ def test_export():
     ]:
         assert os.path.isfile(os.path.join(export_root, f))
 
+
 def test_override(caplog):
     import logging
     import os
+
     from fusesoc.config import Config
     from fusesoc.coremanager import CoreManager
     from fusesoc.librarymanager import Library
@@ -226,15 +228,16 @@ def test_override(caplog):
     core_base_dir = os.path.join(os.path.dirname(__file__), "capi2_cores", "override")
     cm = CoreManager(Config())
     with caplog.at_level(logging.WARNING):
-        cm.add_library(Library("1", os.path.join(core_base_dir,"1")), [])
+        cm.add_library(Library("1", os.path.join(core_base_dir, "1")), [])
     assert caplog.text == ""
 
     with caplog.at_level(logging.WARNING):
-        cm.add_library(Library("2", os.path.join(core_base_dir,"2")), [])
+        cm.add_library(Library("2", os.path.join(core_base_dir, "2")), [])
     assert "Replacing ::basic:0 in" in caplog.text
 
     core = cm.get_core(Vlnv("::basic"))
     assert core.core_root.endswith("2")
+
 
 def test_virtual():
     import os


### PR DESCRIPTION
The "tool list" command line argument was returning nothing when invoked.

After quick inspection, I noticed an import statement was missing and was able to make the very minor fix.