### PR TITLE
Modernize python packaging with pyproject.toml and build-backend

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"


### PR DESCRIPTION
Adding a pyproject.toml with a build backend is the essential first step in modernizing a Python project, as it sets the foundation for utilizing PEP 517 and PEP 518 standards, enabling improved packaging, dependency management, and compatibility with modern build tools, as detailed in the packaging guide: https://packaging.python.org/en/latest/guides/modernize-setup-py-project/#where-to-start.

This update facilitates building and installation using the following recommended commands:

Deprecated | Recommendation
-- | --
python setup.py install | python -m pip install .
python setup.py develop | python -m pip install --editable .
python setup.py sdist | python -m build
python setup.py bdist_wheel | python -m build

