### PR TITLE
coremanager: Pick preferred cores for virtual VLNVs

### DIFF
--- a/tests/capi2_cores/virtual/top_impl1.core
+++ b/tests/capi2_cores/virtual/top_impl1.core
@@ -1,0 +1,21 @@
+CAPI=2:
+# Copyright FuseSoC contributors
+# Licensed under the 2-Clause BSD License, see LICENSE for details.
+# SPDX-License-Identifier: BSD-2-Clause
+
+name: ::top_impl1:0
+filesets:
+  rtl:
+    depend:
+      - ::user:0
+      - ::impl1:0
+    files:
+      - top_impl1.sv
+    file_type: systemVerilogSource
+
+
+targets:
+  default:
+    filesets:
+      - rtl
+    toplevel: top_impl1

--- a/tests/capi2_cores/virtual/top_impl2.core
+++ b/tests/capi2_cores/virtual/top_impl2.core
@@ -1,0 +1,21 @@
+CAPI=2:
+# Copyright FuseSoC contributors
+# Licensed under the 2-Clause BSD License, see LICENSE for details.
+# SPDX-License-Identifier: BSD-2-Clause
+
+name: ::top_impl2:0
+filesets:
+  rtl:
+    depend:
+      - ::user:0
+      - ::impl2:0
+    files:
+      - top_impl2.sv
+    file_type: systemVerilogSource
+
+
+targets:
+  default:
+    filesets:
+      - rtl
+    toplevel: top_impl2

--- a/tests/test_coremanager.py
+++ b/tests/test_coremanager.py
@@ -259,17 +259,22 @@ def test_virtual():
     cm = CoreManager(Config())
     cm.add_library(Library("virtual", core_dir), [])
 
-    root_core = cm.get_core(Vlnv("::user"))
+    test_vectors = {
+        "::top_impl1": ["::impl1:0", "::user:0", "::top_impl1:0"],
+        "::top_impl2": ["::impl2:0", "::user:0", "::top_impl2:0"],
+    }
+    for top_vlnv, expected_deps in test_vectors.items():
+        root_core = cm.get_core(Vlnv(top_vlnv))
 
-    edalizer = Edalizer(
-        toplevel=root_core.name,
-        flags=flags,
-        core_manager=cm,
-        work_root=work_root,
-    )
-    edalizer.run()
+        edalizer = Edalizer(
+            toplevel=root_core.name,
+            flags=flags,
+            core_manager=cm,
+            work_root=work_root,
+        )
+        edalizer.run()
 
-    deps = cm.get_depends(root_core.name, {})
-    deps_names = [str(c) for c in deps]
+        deps = cm.get_depends(root_core.name, {})
+        deps_names = [str(c) for c in deps]
 
-    assert deps_names == ["::impl2:0", "::user:0"]
+        assert deps_names == expected_deps


### PR DESCRIPTION
Add "conflicts" constraints for each core implementing virtual VLNVs, so no two cores implementing the same virtual VLNV may be selected simultaneously.

This change should prevent more than a single implementing core from being selected as the implementation for a virtual VLNV, and when there is an explicit dependency in the tree, that one should be selected.