### PR TITLE
Add better bash_completion with the argcomplete package

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ dependencies = [
   "simplesat>=0.9.1",
   "fastjsonschema",
   "jsonschema2md",
+  "argcomplete",
 ]
 requires-python = ">=3.6, <4"
 


### PR DESCRIPTION
The current bash_completion script is very basic and the completion breaks after entering the first letter of a core name.
Since fusesoc uses the argparse package for argument parsing, we can use the argcomplete package for bash_completion.

Most of the completion is done automatically by argcomplete using the argparse parser.  So there is no need to replicate argument/subparser names in a separate bash_completion file.
I also implemented completion for cores, generators and tools for the specific arguments.

Completion for bash/zsh can be enabled either globally or on a per-command basis.
Global completion can be enabled with the _activate-global-python-argcomplete_  command. Additionally, the fusesoc binary needs the string PYTHON_ARGCOMPLETE_OK in the first 1024 bytes. I would have added this feature to the binary, but i can't find it in the repository. So it is not part of this pull request.
To enable completion for the fusesoc binary only, use the _eval "$(register-python-argcomplete fusesoc)"_ command.
Completion can also be used unofficially with other [shells](https://github.com/kislyuk/argcomplete/tree/develop/contrib) (e.g. powershell).


The disadvantage of this approach is that it adds the argcomplete package as a dependency. However, the argcomplete package seems to be well maintained and is part of the repository of many Linux distributions.