### PR TITLE
add SVN provider

### DIFF
--- a/fusesoc/capi2/json_schema.py
+++ b/fusesoc/capi2/json_schema.py
@@ -149,6 +149,39 @@ capi2_schema = """
           ]
         },
         {
+          "description": "svn Provider",
+          "type": "object",
+          "properties": {
+            "name": {
+              "type": "string",
+              "pattern": "^svn$"
+            },
+            "url": {
+              "type": "string"
+            },
+            "revision": {
+              "type": "string"
+            },
+            "ignore_externals": {
+              "type": "boolean"
+            },
+            "patches": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "cachable": {
+              "type": "boolean"
+            }
+          },
+          "additionalProperties": false,
+          "required": [
+            "name",
+            "url"
+          ]
+        },
+        {
           "description": "url Provider",
           "type": "object",
           "properties": {

--- a/fusesoc/provider/svn.py
+++ b/fusesoc/provider/svn.py
@@ -1,0 +1,31 @@
+# Copyright FuseSoC contributors
+# Licensed under the 2-Clause BSD License, see LICENSE for details.
+# SPDX-License-Identifier: BSD-2-Clause
+
+import logging
+
+from fusesoc.provider.provider import Provider
+from fusesoc.utils import Launcher, cygpath, is_mingw
+
+logger = logging.getLogger(__name__)
+
+
+class Svn(Provider):
+    def _checkout(self, local_dir):
+        if is_mingw():
+            logger.debug("Using cygpath translation")
+            local_dir = cygpath(local_dir)
+
+        args = ["co", "-q"]
+        url = self.config.get("url")
+        revision_number = self.config.get("revision", None)
+        if revision_number:
+            logger.info("Downloading %s revision %s", url, revision_number)
+            args.extend(["-r", revision_number])
+        else:
+            logger.info("Downloading %s", url)
+        if self.config.get("ignore_externals", False):
+            args.append("--ignore-externals")
+        args.extend([url, local_dir])
+
+        Launcher("svn", args).run()

--- a/tests/cores/misc/svn.core
+++ b/tests/cores/misc/svn.core
@@ -1,0 +1,15 @@
+CAPI=2:
+# Copyright FuseSoC contributors
+# Licensed under the 2-Clause BSD License, see LICENSE for details.
+# SPDX-License-Identifier: BSD-2-Clause
+description: Test core for svn provider
+name: ::svncore:0
+provider:
+  name: svn
+  patches: []
+  url: https://svn.code.sf.net/p/gtkwave/code/gtkwave3/share/applications/
+  revision: '1657'
+  ignore_externals: true
+targets:
+  default:
+    filesets: []

--- a/tests/test_provider.py
+++ b/tests/test_provider.py
@@ -59,6 +59,18 @@ def test_github_provider():
         assert fref.read() == fgen.read(), f
 
 
+def test_svn_provider():
+    cache_root = tempfile.mkdtemp("svn_")
+    core = Core(
+        Core2Parser(),
+        os.path.join(cores_root, "misc", "svn.core"),
+        cache_root,
+    )
+
+    core.setup()
+    assert os.path.isfile(os.path.join(core.files_root, "gtkwave.desktop"))
+
+
 @pytest.mark.skip(reason="Problems connecting to OpenCores SVN")
 def test_opencores_provider():
     cache_root = tempfile.mkdtemp("opencores_")


### PR DESCRIPTION
This PR adds a new provider for fetching data from a SVN server given the URL, an optional revision, and can ignore externals. The associated test simply fetches the .desktop file for gtkwave from sourceforge.