### PR TITLE
Replace logging.warn usage with logging.warning

### DIFF
--- a/fusesoc/edalizer.py
+++ b/fusesoc/edalizer.py
@@ -350,7 +350,7 @@ class Edalizer:
                     )
                 param_type_map[name.replace("-", "_")] = _paramtype
             else:
-                logging.warn(
+                logging.warning(
                     "Parameter '{}' has unsupported type '{}' for requested backend".format(
                         name, _paramtype
                     )


### PR DESCRIPTION
logging.warn is an alias to logging.warning since Python 3.3 and will be removed in Python 3.13.