### PR TITLE
Fix library update for git

### DIFF
--- a/fusesoc/provider/git.py
+++ b/fusesoc/provider/git.py
@@ -38,10 +38,10 @@ class Git(Provider):
 
     @staticmethod
     def update_library(library):
-        git_args = ["-C", library.location, "pull"]
+        git_args = ["-C", library.location, "fetch", "--all"]
         try:
-            Git._checkout_library_version(library)
             Launcher("git", git_args).run()
+            Git._checkout_library_version(library)
         except subprocess.CalledProcessError as e:
             raise RuntimeError(str(e))
 


### PR DESCRIPTION
Fetch instead of pull so tags work in sync-version, and do it first so we get updates before checking out the version. 