### PR TITLE
Update simplesat to 0.9.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
   "edalize>=0.4.1",
   "pyparsing>=2.3.1",
   "pyyaml>=6.0",
-  "simplesat>=0.8.0",
+  "simplesat>=0.9.1",
   "fastjsonschema",
   "jsonschema2md",
 ]


### PR DESCRIPTION
This version contains fixes for Python 3.11 and 3.12.

In particular, there were some backslashes in doc comments that were causing syntax warnings in 3.12.7 which are now fixed:

https://github.com/enthought/sat-solver/commit/40f156198042c898e423f4f41da520f3d608d172#diff-05260edff2f9de014b7a81dede2c6fcfc28947d2b9409ae2d8dcaaef090e001fR77