### PR TITLE
Always build non-cached generators in work_root

### DIFF
--- a/tests/test_edalizer.py
+++ b/tests/test_edalizer.py
@@ -217,9 +217,6 @@ def test_generators():
         assert core_name in name_to_core
         core = name_to_core[core_name]
 
-        # ttptttg temporary directory should be removed by now
-        assert not os.path.isdir(core.core_root)
-
     # Test generator input cache and file_input_params
     core_name = f"::generate-testgenerate_with_cache:0"
     assert core_name in name_to_core


### PR DESCRIPTION
Before this change, non-cached generators were only built in work_root if --no-export was enabled which caused race conditions when doing multiple parallel builds.

With this change we also don't remove the temporary generator work directory as that can be useful to have around and will be cleaned out on subsequent builds to the same work_root anyway.