### PR TITLE
Don't leave back stray library after tests

### DIFF
--- a/tests/test_libraries.py
+++ b/tests/test_libraries.py
@@ -225,7 +225,7 @@ def test_library_update_with_initialize(caplog):
 library_root = {library}
 
 [library.vlog_tb_utils]
-location = fusesoc_libraries/vlog_tb_utils
+location = {library}/vlog_tb_utils
 sync-uri = https://github.com/fusesoc/vlog_tb_utils
 sync-type = git
 auto-sync = true
@@ -245,5 +245,5 @@ auto-sync = true
             fs.update_libraries([])
 
         assert "vlog_tb_utils does not exist. Trying a checkout" in caplog.text
-        assert "Cloning library into fusesoc_libraries/vlog_tb_utils" in caplog.text
+        assert f"Cloning library into {library}/vlog_tb_utils" in caplog.text
         assert "Updating..." in caplog.text


### PR DESCRIPTION
The new test `test_library_update_with_initialize` introduced in #720 did use the `fusesoc_libraries`-directory in the repository root and, in contrast to other tests in that module, did not delete it afterwards. This causes a leftover library in the repository root after running the testsuite. This is unpleasant and a bug in the test.

This commit fixes it by cloning into the temporary directory, which was already created for just this use-case.