### PR TITLE
Fix erroneous relative path resolution

### DIFF
--- a/fusesoc/config.py
+++ b/fusesoc/config.py
@@ -103,8 +103,8 @@ class Config:
         if os.path.isabs(expanded):
             return expanded
         else:
-            cfg_file_dir = os.path.dirname(self._path)
-            return os.path.join(cfg_file_dir, expanded)
+            cfg_file_dir = os.path.dirname(os.path.abspath(self._path))
+            return os.path.normpath(os.path.join(cfg_file_dir, expanded))
 
     def _path_from_cfg(self, name):
         as_str = self._cp.get(Config.default_section, name, fallback=None)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -92,6 +92,47 @@ def test_config_relative_path():
             assert getattr(conf, name) == os.path.join(abs_td, name)
 
 
+def test_config_relative_path_starts_with_dot():
+    with tempfile.TemporaryDirectory() as td:
+        config_path = os.path.join(td, "fusesoc.conf")
+        with open(config_path, "w") as tcf:
+            tcf.write(
+                EXAMPLE_CONFIG.format(
+                    build_root="./build_root",
+                    cache_root="./cache_root",
+                    cores_root="./cores_root",
+                    library_root="./library_root",
+                )
+            )
+
+        conf = Config(tcf.name)
+        for name in ["build_root", "cache_root", "library_root"]:
+            abs_td = os.path.abspath(td)
+            assert getattr(conf, name) == os.path.join(abs_td, name)
+
+
+def test_config_relative_path_with_local_config():
+    prev_dir = os.getcwd()
+    with tempfile.TemporaryDirectory() as td:
+        os.chdir(td)
+        config_path = "fusesoc.conf"
+        with open(config_path, "w") as tcf:
+            tcf.write(
+                EXAMPLE_CONFIG.format(
+                    build_root="build_root",
+                    cache_root="cache_root",
+                    cores_root="cores_root",
+                    library_root="library_root",
+                )
+            )
+
+        conf = Config(tcf.name)
+        for name in ["build_root", "cache_root", "library_root"]:
+            abs_td = os.path.abspath(td)
+            assert getattr(conf, name) == os.path.join(abs_td, name)
+    os.chdir(prev_dir)
+
+
 def test_config_libraries():
     tcf = tempfile.NamedTemporaryFile(mode="w+")
     tcf.write(


### PR DESCRIPTION
Currently FuseSoC has two problems related to relative path resolution, 

The more severe one occurs when the fusesoc.conf file is in the current directory, in that case the code 

[files_read = self._cp.read(config_files)](https://github.com/olofk/fusesoc/blob/b604f53daf3c28aedd196c5cc1335f3161280201/fusesoc/config.py#L40)

returns only the file name, then in the function [_resolve_path_from_cfg](https://github.com/olofk/fusesoc/blob/b604f53daf3c28aedd196c5cc1335f3161280201/fusesoc/config.py#L95-L107) when `os.path.dirname` is called, an empty string is returned and when joined to form the final path we get a broken result

A second issue that I found is when referencing to a relative path starting with a dot, for example `./build_root` that dot stays in the path producing a result like `/abs/path/to/./build_root` which although is a valid path, fails path comparisons, like the ones that are done for `ignored_dirs`

This PR includes tests for both cases and fixes them.