### PR TITLE
Fix canonical path vs symlink comparison

### DIFF
--- a/fusesoc/config.py
+++ b/fusesoc/config.py
@@ -103,7 +103,7 @@ class Config:
         if os.path.isabs(expanded):
             return expanded
         else:
-            cfg_file_dir = os.path.dirname(os.path.abspath(self._path))
+            cfg_file_dir = os.path.dirname(os.path.realpath(self._path))
             return os.path.normpath(os.path.join(cfg_file_dir, expanded))
 
     def _path_from_cfg(self, name):

--- a/fusesoc/coremanager.py
+++ b/fusesoc/coremanager.py
@@ -286,7 +286,7 @@ class CoreManager:
         visited = set()
         for root, dirs, files in os.walk(path, followlinks=True):
             ignore_tree = ("FUSESOC_IGNORE" in files) or (
-                os.path.abspath(root) in ignored_dirs
+                os.path.realpath(root) in ignored_dirs
             )
             if ignore_tree:
                 del dirs[:]

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -88,7 +88,7 @@ def test_config_relative_path():
 
         conf = Config(tcf.name)
         for name in ["build_root", "cache_root", "library_root"]:
-            abs_td = os.path.abspath(td)
+            abs_td = os.path.realpath(td)
             assert getattr(conf, name) == os.path.join(abs_td, name)
 
 
@@ -107,7 +107,7 @@ def test_config_relative_path_starts_with_dot():
 
         conf = Config(tcf.name)
         for name in ["build_root", "cache_root", "library_root"]:
-            abs_td = os.path.abspath(td)
+            abs_td = os.path.realpath(td)
             assert getattr(conf, name) == os.path.join(abs_td, name)
 
 
@@ -128,7 +128,7 @@ def test_config_relative_path_with_local_config():
 
         conf = Config(tcf.name)
         for name in ["build_root", "cache_root", "library_root"]:
-            abs_td = os.path.abspath(td)
+            abs_td = os.path.realpath(td)
             assert getattr(conf, name) == os.path.join(abs_td, name)
     os.chdir(prev_dir)
 


### PR DESCRIPTION
This PR fixes the macOS tests, which were broken by pull request #726 . The issue occurs because on macOS, **/var** and **/tmp** are symbolic links to **/private/var** and **/private/tmp**. When calling `abspath` on a relative path or filename, we get the canonical (real) path. However, the `TemporaryDirectory()` function used in the tests returns a symbolic link that is already an absolute path (starting with **/var**), so calling `abspath` on it does nothing.

I also replaced the `abspath` call when processing the ignored directories with `realpath` to avoid a mismatch between a symlink and the canonical path of the same directory.

Everything seems to be working now, but I'm still a bit worried that there might be another comparison between symlink paths and real paths elsewhere in the code, since `abspath` is used in multiple places. A more comprehensive solution might be to replace all `abspath` calls with `realpath`, but I didn't want to make such an intrusive change to the codebase.