### PR TITLE
Use pydantic for easy runtime data validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,12 +23,11 @@ jobs:
         # https://github.com/olofk/fusesoc/issues/528
         #- { icon: 🧊, name: windows-latest }
         pyver:
-          - '3.7'
-          - '3.8'
-          - '3.9'
           - '3.10'
           - '3.11'
           - '3.12'
+          - '3.13'
+          - '3.14'
         exclude:
           #Fails because github can't find an arm64 image for Python 3.7???
           - os: {name: macos-latest}

--- a/fusesoc/config.py
+++ b/fusesoc/config.py
@@ -304,7 +304,7 @@ class Config:
 
         self._cp.add_section(section_name)
 
-        self._cp.set(section_name, "location", library.location)
+        self._cp.set(section_name, "location", str(library.location))
 
         if library.sync_type:
             self._cp.set(section_name, "sync-uri", library.sync_uri)

--- a/fusesoc/librarymanager.py
+++ b/fusesoc/librarymanager.py
@@ -4,41 +4,39 @@
 
 import logging
 import os
+from typing import Literal
 
 from fusesoc.provider.provider import get_provider
+from pydantic import model_validator
+from pydantic.dataclasses import dataclass
+from typing_extensions import Self
 
 logger = logging.getLogger(__name__)
 
 
+@dataclass(config={"validate_assignment": True})
 class Library:
-    def __init__(
-        self,
-        name,
-        location,
-        sync_type=None,
-        sync_uri=None,
-        sync_version=None,
-        auto_sync=True,
-    ):
-        if sync_type and sync_type not in ["local", "git", "url"]:
+    name: str
+    location: str
+    sync_type: Literal["local", "git", "url"] | None = None
+    sync_uri: str | None = None
+    sync_version: str | None = None
+    auto_sync: bool = True
+
+    @model_validator(mode="after")
+    def check_instances(self) -> Self:
+        if self.sync_type and self.sync_type not in ("local", "git", "url"):
             raise ValueError(
                 "Library {} ({}) Invalid sync-type '{}'".format(
-                    name, location, sync_type
+                    self.name, self.location, self.sync_type
                 )
             )
-
-        if sync_type in ["git", "url"]:
-            if not sync_uri:
+        if self.sync_type in ("git", "url"):
+            if self.sync_uri is None:
                 raise ValueError(
-                    f"Library name ({location}) {sync_uri} must be set when using sync_type '{sync_type}'"
+                    f"Library {self.name} ({self.location}) 'sync_uri' must be set when using sync_type '{self.sync_type}'"
                 )
-
-        self.name = name
-        self.location = location
-        self.sync_type = sync_type or "local"
-        self.sync_uri = sync_uri
-        self.sync_version = sync_version
-        self.auto_sync = auto_sync
+        return self
 
     def update(self, force=False):
         def lib(s):

--- a/fusesoc/librarymanager.py
+++ b/fusesoc/librarymanager.py
@@ -6,10 +6,11 @@ import logging
 import os
 from typing import Literal
 
-from fusesoc.provider.provider import get_provider
 from pydantic import model_validator
 from pydantic.dataclasses import dataclass
 from typing_extensions import Self
+
+from fusesoc.provider.provider import get_provider
 
 logger = logging.getLogger(__name__)
 
@@ -25,16 +26,11 @@ class Library:
 
     @model_validator(mode="after")
     def check_instances(self) -> Self:
-        if self.sync_type and self.sync_type not in ("local", "git", "url"):
-            raise ValueError(
-                "Library {} ({}) Invalid sync-type '{}'".format(
-                    self.name, self.location, self.sync_type
-                )
-            )
         if self.sync_type in ("git", "url"):
             if self.sync_uri is None:
                 raise ValueError(
-                    f"Library {self.name} ({self.location}) 'sync_uri' must be set when using sync_type '{self.sync_type}'"
+                    f"Library {self.name} ({self.location}) "
+                    f"sync-uri must be set when using sync_type '{self.sync_type}'"
                 )
         return self
 

--- a/fusesoc/utils.py
+++ b/fusesoc/utils.py
@@ -17,6 +17,8 @@ except ImportError:
     from yaml import SafeDumper as YamlDumper
     from yaml import SafeLoader as YamlLoader
 
+from pydantic import validate_call
+
 from fusesoc.capi2.inheritance import Inheritance
 
 logger = logging.getLogger(__name__)
@@ -60,7 +62,8 @@ def cygpath(win_path):
     return path.decode("ascii").strip()
 
 
-def unique_dirs(file_list):
+@validate_call
+def unique_dirs(file_list: list[str]) -> list[str]:
     return list({os.path.dirname(f) for f in file_list})
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,11 +28,12 @@ dependencies = [
   "edalize>=0.4.1",
   "pyparsing>=2.3.1",
   "pyyaml>=6.0",
+  "pydantic>=2.13.3",
   "simplesat>=0.9.1",
   "fastjsonschema",
   "argcomplete",
 ]
-requires-python = ">=3.6, <4"
+requires-python = ">=3.10, <4"
 
 [project.urls]
 Homepage = "https://fusesoc.net"

--- a/tests/test_coremanager.py
+++ b/tests/test_coremanager.py
@@ -374,14 +374,14 @@ def test_virtual_non_deterministic_virtual(caplog):
 
 
 def test_mapping_success_cases():
-    from pathlib import Path
+    import os
 
     from fusesoc.config import Config
     from fusesoc.coremanager import CoreManager
     from fusesoc.librarymanager import Library
     from fusesoc.vlnv import Vlnv
 
-    core_dir = Path(__file__).parent / "capi2_cores" / "mapping"
+    core_dir = os.path.join(os.path.dirname(__file__), "capi2_cores", "mapping")
 
     top = "test_mapping:t:top"
     top_vlnv = Vlnv(top)
@@ -443,13 +443,13 @@ def test_mapping_success_cases():
 
 
 def test_mapping_failure_cases():
-    from pathlib import Path
+    import os
 
     from fusesoc.config import Config
     from fusesoc.coremanager import CoreManager
     from fusesoc.librarymanager import Library
 
-    core_dir = Path(__file__).parent / "capi2_cores" / "mapping"
+    core_dir = os.path.join(os.path.dirname(__file__), "capi2_cores", "mapping")
 
     for mappings in (
         ["test_mapping:m:non_existent"],

--- a/tests/test_edalizer.py
+++ b/tests/test_edalizer.py
@@ -155,6 +155,7 @@ def test_tool_or_flow():
 
 
 def test_generators():
+    import os
     import shutil
     import tempfile
     from pathlib import Path
@@ -165,8 +166,8 @@ def test_generators():
     from fusesoc.librarymanager import Library
     from fusesoc.vlnv import Vlnv
 
-    tests_dir = Path(__file__).parent
-    cores_dir = tests_dir / "capi2_cores" / "misc" / "generate"
+    tests_dir = os.path.dirname(__file__)
+    cores_dir = os.path.join(tests_dir, "capi2_cores", "misc")
 
     lib = Library("edalizer", cores_dir)
 


### PR DESCRIPTION
I've found writing more data oriented python has made my projects less bug prone and easily maintainable. [Pydantic](
https://docs.pydantic.dev/2.10/why/) is a very popular library that can provide runtime data validation from standard type hints.

This PR shows how Pydantic could be introduced incrementally. I've used the `@validate_call` decorator to check the arguments provided to `unique_dirs`. I've also made `Library` a data class with runtime type checking on initialization and assignment. *(I normally like to use `frozen=True`, but was trying to keep changes to a minimum.)*

I have also bumped the python version to 3.10. I chose 3.10 because it adds nice ergonomic improvements to type hints, e.g. `str | list` as oppose to `Union[str, list]`. Version 3.9 will also [become end-of-life before the end of the year](https://devguide.python.org/versions/). The latest Pydantic only requires python version 3.8, though so we don't have to jump to 3.10 in order to use it.