### PR TITLE
Don't cache failed generators

### DIFF
--- a/fusesoc/edalizer.py
+++ b/fusesoc/edalizer.py
@@ -672,7 +672,17 @@ class Ttptttg:
                 )
             else:
                 shutil.rmtree(generator_cwd, ignore_errors=True)
-            self._run(generator_cwd)
+            try:
+                self._run(generator_cwd)
+            except:
+                # If the generator invocation failed for any reason, its output
+                # directory is removed. While this is bad for debugging failing
+                # generators, it at least prevents the next FuseSoC-run to
+                # assume, that the generator was successful and hence a failed
+                # generator is retried on the next FuseSoC-run.
+                logger.debug("Generator failed, removing its output files")
+                shutil.rmtree(generator_cwd, ignore_errors=False)
+                raise
             # TODO: Release cache lock
 
         cores = []


### PR DESCRIPTION
When FuseSoC runs generators, the output is cached if the generator re-
quests so. While this is generally a good idea, the cached output must
not be used in subsequent runs if the generator fails with a non-zero
exit code. In that case, the generator should be re-invoked in the next
run to not need to user to manually run `fusesoc gen clean` to fix a
faulty cache entry. Therefore this pull request adds in a check, if the
generator call was successful and if it isn't the caching is prevented.

The first commit adds a test for a failing generator called in two sub-
sequent FuseSoC-runs, expecting it to be called twice. The second commit
changes the code calling generators to check for errors, taking action
and re-raising that error.
Currently the aforementioned action is to delete the entire working
directory of the generator, since this will fail the current check for a
cached generator result:

https://github.com/olofk/fusesoc/blob/1403437166ad787fa75a70fe1b42d785e1470a45/fusesoc/edalizer.py#L657

As an alternative, one could store a file `.success` (or similar) in the
generator directory and only use the cache directory if that file is
present there.