### PR TITLE
Introduce the mappings feature

### DIFF
--- a/doc/source/user/build_system/index.rst
+++ b/doc/source/user/build_system/index.rst
@@ -38,5 +38,7 @@ A full reference documentation on the CAPI2 core file format can be found in the
    filters.rst
    flags.rst
    generators.rst
+   virtual_cores.rst
+   mappings.rst
    hooks.rst
    vpi.rst

--- a/doc/source/user/build_system/mappings.rst
+++ b/doc/source/user/build_system/mappings.rst
@@ -1,0 +1,40 @@
+.. _ug_build_system_mappings:
+
+Mappings: Replace cores in the dependency tree
+==============================================
+
+Mappings allow a user of a core to substitute dependencies of the core with other cores without having to edit any of the core or it's dependencies files.
+An example use case is making use of an existing core but substituting one of it's dependencies with a version that some desired changes (e.g. bug fixes).
+
+If you are looking to provide a core with multiple implementations, virtual cores is the recommended and more semantic solution.
+See :ref:`ug_build_system_virtual_cores` for more information on virtual cores.
+Note: virtual cores can also be substituted in mappings.
+
+Declaring mappings
+------------------
+
+Each core file can have one mapping.
+An example mapping core file:
+
+.. code:: yaml
+
+    name: "local:map:override_fpu_and_fifo"
+    mapping:
+      "vendor:lib:fpu":  "local:lib:fpu"
+      "vendor:lib:fifo": "local:lib:fifo"
+
+The example above is a core file with only a mapping property, but any core file may contain a mapping in addition to other properties (e.g. filesets, targets & generators).
+
+Applying mappings
+-----------------
+
+To apply a mapping, provide the VLNV of the core file that contains the desired
+mapping with `fusesoc run`'s `--mapping` argument. Multiple mappings may be
+provided as shown below.
+
+.. code:: sh
+
+    fusesoc run \
+      --mapping local:map:override_fpu_and_fifo \
+      --mapping local:map:another_mapping \
+      vendor:top:main

--- a/doc/source/user/build_system/virtual_cores.rst
+++ b/doc/source/user/build_system/virtual_cores.rst
@@ -1,0 +1,8 @@
+.. _ug_build_system_virtual_cores:
+
+Virtual Cores: Provide a common interface
+=========================================
+
+.. todo::
+
+   Document virtual cores.

--- a/fusesoc/capi2/core.py
+++ b/fusesoc/capi2/core.py
@@ -10,6 +10,8 @@ import os
 import shutil
 import warnings
 from filecmp import cmp
+from types import MappingProxyType
+from typing import Mapping, Optional
 
 from fusesoc import utils
 from fusesoc.capi2.coredata import CoreData
@@ -630,3 +632,7 @@ Targets:
 
     def get_description(self):
         return self._coredata.get_description()
+
+    @property
+    def mapping(self) -> Optional[Mapping[str, str]]:
+        return MappingProxyType(self._coredata.get("mapping", {}))

--- a/fusesoc/capi2/json_schema.py
+++ b/fusesoc/capi2/json_schema.py
@@ -77,18 +77,18 @@ capi2_schema = """
                 "type": "object",
                 "properties": {
                   "define": {
-		    "description": "Defines to be used for this file. These defines will be added to those specified in the target parameters section. If a define is specified both here and in the target parameter section, the value specified here will take precedence.  The parameter default value can be set here with ``param=value``",
-		    "type": "object",
-		    "patternProperties": {
-		      "^.+$": {
-			"anyOf": [
-			  { "type": "string" },
-			  { "type": "number" },
-			  { "type": "boolean"}
-			]
-		      }
-		    }
-		  },
+                    "description": "Defines to be used for this file. These defines will be added to those specified in the target parameters section. If a define is specified both here and in the target parameter section, the value specified here will take precedence.  The parameter default value can be set here with ``param=value``",
+                    "type": "object",
+                    "patternProperties": {
+                      "^.+$": {
+                        "anyOf": [
+                          { "type": "string" },
+                          { "type": "number" },
+                          { "type": "boolean"}
+                        ]
+                      }
+                    }
+                  },
                   "is_include_file": {
                     "description": "Treats file as an include file when true",
                     "type": "boolean"

--- a/fusesoc/capi2/json_schema.py
+++ b/fusesoc/capi2/json_schema.py
@@ -52,6 +52,15 @@ capi2_schema = """
       "items": {
         "type": "string"
       }
+    },
+    "mapping": {
+      "description": "",
+      "type": "object",
+      "patternProperties": {
+        "^.+$": {
+          "type": "string"
+        }
+      }
     }
   },
   "additionalProperties": false,

--- a/fusesoc/main.py
+++ b/fusesoc/main.py
@@ -307,6 +307,8 @@ def run(fs, args):
         else:
             flags[flag] = True
 
+    fs.cm.db.mapping_set(args.mapping)
+
     if args.lockfile is not None:
         try:
             fs.cm.db.load_lockfile(args.lockfile)

--- a/fusesoc/main.py
+++ b/fusesoc/main.py
@@ -679,6 +679,12 @@ def get_parser():
         help="Lockfile file path",
         type=pathlib.Path,
     )
+    parser_run.add_argument(
+        "--mapping",
+        help="The VLNV of a core's mapping to apply.",
+        default=[],
+        action="append",
+    )
     parser_run.set_defaults(func=run)
 
     # config subparser

--- a/fusesoc/vlnv.py
+++ b/fusesoc/vlnv.py
@@ -108,6 +108,8 @@ class Vlnv:
             self.vendor, self.library, self.name, self.version, revision
         )
 
+    __repr__ = __str__
+
     def __hash__(self):
         return hash(str(self))
 

--- a/tests/capi2_cores/mapping/a.core
+++ b/tests/capi2_cores/mapping/a.core
@@ -1,0 +1,8 @@
+CAPI=2:
+# Copyright FuseSoC contributors
+# Licensed under the 2-Clause BSD License, see LICENSE for details.
+# SPDX-License-Identifier: BSD-2-Clause
+
+name: test_mapping:l:a:0
+virtual:
+ - test_mapping:v:x:0

--- a/tests/capi2_cores/mapping/b.core
+++ b/tests/capi2_cores/mapping/b.core
@@ -1,0 +1,6 @@
+CAPI=2:
+# Copyright FuseSoC contributors
+# Licensed under the 2-Clause BSD License, see LICENSE for details.
+# SPDX-License-Identifier: BSD-2-Clause
+
+name: test_mapping:l:b:0

--- a/tests/capi2_cores/mapping/c.core
+++ b/tests/capi2_cores/mapping/c.core
@@ -1,0 +1,9 @@
+CAPI=2:
+# Copyright FuseSoC contributors
+# Licensed under the 2-Clause BSD License, see LICENSE for details.
+# SPDX-License-Identifier: BSD-2-Clause
+
+name: test_mapping:l:c:0
+
+mapping:
+  "test_mapping:l:c": "test_mapping:v:x"

--- a/tests/capi2_cores/mapping/d.core
+++ b/tests/capi2_cores/mapping/d.core
@@ -1,0 +1,10 @@
+CAPI=2:
+# Copyright FuseSoC contributors
+# Licensed under the 2-Clause BSD License, see LICENSE for details.
+# SPDX-License-Identifier: BSD-2-Clause
+
+name: test_mapping:l:d:0
+
+mapping:
+  "test_mapping:l:b": "test_mapping:l:d"
+  "test_mapping:l:c": "test_mapping:l:e"

--- a/tests/capi2_cores/mapping/e.core
+++ b/tests/capi2_cores/mapping/e.core
@@ -1,0 +1,6 @@
+CAPI=2:
+# Copyright FuseSoC contributors
+# Licensed under the 2-Clause BSD License, see LICENSE for details.
+# SPDX-License-Identifier: BSD-2-Clause
+
+name: test_mapping:l:e:0

--- a/tests/capi2_cores/mapping/f.core
+++ b/tests/capi2_cores/mapping/f.core
@@ -1,0 +1,6 @@
+CAPI=2:
+# Copyright FuseSoC contributors
+# Licensed under the 2-Clause BSD License, see LICENSE for details.
+# SPDX-License-Identifier: BSD-2-Clause
+
+name: test_mapping:l:f:0

--- a/tests/capi2_cores/mapping/map_rec.core
+++ b/tests/capi2_cores/mapping/map_rec.core
@@ -1,0 +1,9 @@
+CAPI=2:
+# Copyright FuseSoC contributors
+# Licensed under the 2-Clause BSD License, see LICENSE for details.
+# SPDX-License-Identifier: BSD-2-Clause
+
+name: "test_mapping:m:map_rec:0"
+mapping:
+  "test_mapping:l:b": "test_mapping:l:c"
+  "test_mapping:l:c": "test_mapping:l:b"

--- a/tests/capi2_cores/mapping/map_vers.core
+++ b/tests/capi2_cores/mapping/map_vers.core
@@ -1,0 +1,8 @@
+CAPI=2:
+# Copyright FuseSoC contributors
+# Licensed under the 2-Clause BSD License, see LICENSE for details.
+# SPDX-License-Identifier: BSD-2-Clause
+
+name: test_mapping:m:map_vers:0
+mapping:
+  "test_mapping:l:b:0": "test_mapping:l:c"

--- a/tests/capi2_cores/mapping/top.core
+++ b/tests/capi2_cores/mapping/top.core
@@ -1,0 +1,21 @@
+CAPI=2:
+# Copyright FuseSoC contributors
+# Licensed under the 2-Clause BSD License, see LICENSE for details.
+# SPDX-License-Identifier: BSD-2-Clause
+
+name: "test_mapping:t:top:0"
+filesets:
+  rtl:
+    depend:
+      - "test_mapping:v:x:0"
+      - "test_mapping:l:b:0"
+      - "test_mapping:l:c:0"
+
+mapping:
+  "test_mapping:v:x": "test_mapping:l:f"
+
+targets:
+  default:
+    filesets:
+      - rtl
+    toplevel: top


### PR DESCRIPTION
Introduce the mappings feature discussed in https://github.com/olofk/fusesoc/pull/727. *See https://github.com/olofk/fusesoc/pull/727#issuecomment-2647695340 for context.*

Description of the feature from the documentation:
> Mappings allow a user of a core to substitute dependencies of the core with other cores without having to edit any of the core or it's dependencies files. An example use case is making use of an existing core but substituting one of it's dependencies with a version that some desired changes (e.g. bug fixes).

I've restricted the flexibility of mappings in the interest of keeping this patch set smaller:
- They cannot be recursive.
- They cannot include versions.
- Cores conflicting with substitutes aren't removed from the dependency tree.
  - For OpenTitan's use case, a flag can be used to disable the default primitives so there are no conflicts.

These restrictions can be lifted in the future commits, if deemed useful.

The commits are all self contained: lints and tests pass for every commit, so they don't need to be squashed. However, re-ordering may make sense.