### PR TITLE
Moved jsonschema2md to doc requirements

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,3 +1,4 @@
+jsonschema2md
 myst_parser >= 0.18.0
 Sphinx >= 6.2.1
 sphinx-rtd-theme >= 1.2.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,6 @@ dependencies = [
   "pyyaml>=6.0",
   "simplesat>=0.9.1",
   "fastjsonschema",
-  "jsonschema2md",
   "argcomplete",
 ]
 requires-python = ">=3.6, <4"


### PR DESCRIPTION
`jsonschema2md` is not actually needed by FuseSoC it's self. It's only needed for documentation, so should live in `doc/requirements.txt`.

I found this when updating the nixpkgs' version of FuseSoC (https://github.com/NixOS/nixpkgs/pull/419605). `jsonschema2md` is nasty to package due to a seemingly cyclical dependency in the build of one of it's build dependencies: https://github.com/sbrunner/poetry-plugin-tweak-dependencies-version/blob/e40b1a1093109639d99ff0d4f33f430252dae9e4/pyproject.toml#L77