### PR TITLE
Adds license field to CAPI2 schema

### DIFF
--- a/fusesoc/capi2/json_schema.py
+++ b/fusesoc/capi2/json_schema.py
@@ -9,6 +9,24 @@ capi2_schema = """
       "description": "Short description of core",
       "type": "string"
     },
+    "license": {
+      "oneOf": [
+        {
+          "type": "string",
+          "description": "SPDX license identifier. See https://spdx.org/licenses/ for valid values."
+        },
+        {
+          "type": "object",
+          "properties": {
+            "name": { "type": "string" },
+            "text": { "type": "string" }
+          },
+          "required": ["name", "text"],
+          "additionalProperties": false,
+          "description": "Custom defined license"
+        }
+      ]
+    },
     "filesets": { "$ref": "#/$defs/filesets" },
     "generate": { "$ref": "#/$defs/generate" },
     "generators": { "$ref": "#/$defs/generators" },


### PR DESCRIPTION
Adds support for specifying license information in the CAPI2
schema. The license can be provided as an SPDX identifier string
or as a custom license object with name and text attributes.

This allows for better documentation and identification of the
licenses used in FuseSoC cores.
