### PR TITLE
Expand the autotype filter to include commonly used file types

### DIFF
--- a/fusesoc/filters/autotype.py
+++ b/fusesoc/filters/autotype.py
@@ -7,13 +7,32 @@ logger = logging.getLogger(__name__)
 class Autotype:
     def run(self, edam, work_root):
         type_map = {
+            # HDL sources
+            ".sv": "systemVerilogSource",
+            ".v": "verilogSource",
+            ".vhd": "vhdlSource",
+            ".vhdl": "vhdlSource",
+
+            # Vivado IP
+            ".xci": "xci",
+            ".bd": "bd",
+
+            # Verilator
+            ".vlt": "vlt",
+
+            # Design constraints
+            ".sdc": "SDC", # Synopsys-style
+            ".xdc": "xdc", # Vivado-style
+
+            # Software
             ".c": "cSource",
             ".cpp": "cppSource",
-            ".sv": "systemVerilogSource",
+
+            # Scripts
             ".tcl": "tclSource",
-            ".v": "verilogSource",
-            ".vlt": "vlt",
-            ".xdc": "xdc",
+
+            # Register map definitions
+            ".rdl": "systemRDL",
         }
         for f in edam["files"]:
             if not "file_type" in f:


### PR DESCRIPTION
This change expands the `autotype` filter to include several additional file extensions that are popular and unambiguous enough that they ought to be included.

Added the following file type filters:
* `*.vhd` or `*.vhdl` --> "vhdlSource" (I was surprised this was missing)
* `*.xci` --> "xci" (matches the existing file_type used in the Vivado flow)
* `*.bd` --> "bd" (matches the existing file_type used in the Vivado flow)
* `*.sdc` --> "SDC"
* `*.rdl` --> "systemRDL" (selfishly adding since I'll be building out some FuseSoC RDL tooling!)

I also organized the type map into groups to make it easier to maintain in the future.