### PR TITLE
CAPI2: Variables

### DIFF
--- a/doc/source/user/build_system/index.rst
+++ b/doc/source/user/build_system/index.rst
@@ -38,6 +38,7 @@ A full reference documentation on the CAPI2 core file format can be found in the
    filters.rst
    flags.rst
    generators.rst
+   variables.rst
    virtual_cores.rst
    mappings.rst
    hooks.rst

--- a/doc/source/user/build_system/variables.rst
+++ b/doc/source/user/build_system/variables.rst
@@ -23,7 +23,8 @@ Setting variables
 User-defined variables can be set as a dict of key/value pairs in the variables section of a target, or they can be applied on the command line, using the ``--var`` argument to ``fusesoc run``.
 Failing to define a variable that is used in a core file will result in an error.
 Examples:
-.. code:: bash
+
+.. code-block:: bash
 
   # Set the variable "frequency" to "100MHz".
   fusesoc run --var "frequency=100MHz" fusesoc:examples:varexample:1.0.0
@@ -62,6 +63,7 @@ Variables can be used in :term:`core files <core file>` to effect the value of a
 * Variables can be used in string, int, and boolean CAPI2 values.
 
 The following example shows how to use variables in a core file.
+
 .. code-block:: yaml
 
    # An excerpt from a core file.

--- a/doc/source/user/build_system/variables.rst
+++ b/doc/source/user/build_system/variables.rst
@@ -1,0 +1,93 @@
+.. _ug_build_system_variables:
+
+Variables: Flexibility in Cores
+==================================
+
+Variables in FuseSoC are global string, int, or boolean variables that influence build dependency resolution.
+Variables can be used in multiple :term:`core files <core file>` to replace $ tagged variables with a value defined at the top level, or via the CLI.
+For example, generators using parameters such as PROTOCOL or FREQUENCY can be configured differently, even when they do not exist in the same core as your toplevel.
+
+Facts about variables:
+
+* Variables are global string, int, or boolean variables.
+* Variables are global, i.e. they apply to the whole build.
+* All cores see the same variables under the same name.
+* A valid variable name starts with a letter, and consists only of letters from the English alphabet, numbers, and the underscore (``_``).
+* Variable names are case-sensitive.
+* It is recommended to use lower-case letters only.
+* Variables are very similar to flags
+
+Setting variables
+-----------------
+
+User-defined variables can be set as a dict of key/value pairs in the variables section of a target, or they can be applied on the command line, using the ``--var`` argument to ``fusesoc run``.
+Failing to define a variable that is used in a core file will result in an error.
+Examples:
+.. code:: bash
+
+  # Set the variable "frequency" to "100MHz".
+  fusesoc run --var "frequency=100MHz" fusesoc:examples:varexample:1.0.0
+
+  # Set two variables, "frequency" and "protocol".
+  fusesoc run --var "frequency=100MHz" --var "protocol=AXI4" fusesoc:examples:varexample:1.0.0
+
+
+The ``--var`` argument can be used multiple times to set multiple variables.
+
+
+.. note::
+
+  Order matters!
+  The FuseSoC command line is "context sensitive."
+  Place the ``--var`` argument after the ``run`` command, but before the name of the core you are building.
+
+Default values for variables can be set directly in the variables section of a target, like this.
+
+.. code-block:: yaml
+
+   # An excerpt from a core file.
+   targets:
+     sim:
+       # ...
+       variables:
+         frequency : 250MHz # Build the design to run at 250MHz by default
+         protocol: AXI4  # Use AXI4 to for our generated registers by default
+
+Using variables
+-----------
+
+Variables can be used in :term:`core files <core file>` to effect the value of a CAPI2 key-value pair.
+
+* To set a value in a CAPI2 string, prefix the variable name with a dollar sign (``$``) and place it where you would normally place a your CAPI2 value.
+* Variables can be used in string, int, and boolean CAPI2 values.
+
+The following example shows how to use variables in a core file.
+.. code-block:: yaml
+
+   # An excerpt from a core file.
+   name: "fusesoc:examples:varexample"
+
+   filesets:
+     module:
+     depend:
+       - fusesoc:examples:my_generator_core
+     files:
+       - rtl/module.sv
+      file_type: systemVerilogSource
+
+   generators:
+     my_generator:
+       generator: my_generator_class
+       parameters:
+         PROTOCOL : $protocol  # Use the protocol variable to set the PROTOCOL parameter
+
+   targets:
+     default: &default
+       filesets: [module]
+       generate: [my_generator]
+
+
+Variables can be used in many places in core files, and are designed to be inherently flexible.
+
+To find all valid places where variables can be used, refer to the :ref:`ref_capi2`.
+Expressions with variables can be used whenever the data type is ``StringWithUseFlags``, ``StringWithUseFlagsOrDict``, or ``StringWithUseFlagsOrList``.

--- a/fusesoc/capi2/json_schema.py
+++ b/fusesoc/capi2/json_schema.py
@@ -622,6 +622,15 @@ capi2_schema = """
                   "$ref": "#/$defs/any_type"
                 }
               }
+            },
+            "variables" : {
+              "description": "Default values of variables",
+              "type": "object",
+              "patternProperties": {
+                "^.+$": {
+                  "$ref": "#/$defs/any_type"
+                }
+              }
             }
           },
           "patternProperties": {

--- a/fusesoc/coremanager.py
+++ b/fusesoc/coremanager.py
@@ -326,7 +326,7 @@ class CoreDB:
             if not only_matching_vlnv:
                 _flags["is_toplevel"] = core.name == top_core
                 try:
-                    _depends = core.get_depends(_flags)
+                    _depends = core.get_depends(_flags, _flags.get("variables", {}))
                 except SyntaxError as e:
                     logger.warning(
                         f"Ignoring {core.name} due to syntax error in dependencies: {e.msg}"

--- a/fusesoc/fusesoc.py
+++ b/fusesoc/fusesoc.py
@@ -90,8 +90,10 @@ class Fusesoc:
     def get_generators(self):
         return self.cm.get_generators()
 
-    def get_work_root(self, core, flags):
-        flow = core.get_flow(flags)
+    def get_work_root(self, core, flags, variables=None):
+        if variables is None:
+            variables = {}
+        flow = core.get_flow(flags, variables)
 
         target = flags["target"]
 
@@ -114,9 +116,9 @@ class Fusesoc:
 
         return work_root
 
-    def get_backend(self, core, flags, backendargs=[]):
+    def get_backend(self, core, flags, variables, backendargs=[]):
 
-        work_root = self.get_work_root(core, flags)
+        work_root = self.get_work_root(core, flags, variables)
 
         if not self.config.no_export:
             export_root = os.path.join(work_root, "src")
@@ -126,7 +128,7 @@ class Fusesoc:
 
         edam_file = os.path.join(work_root, core.name.sanitized_name + ".eda.yml")
 
-        flow = core.get_flow(flags)
+        flow = core.get_flow(flags, variables)
 
         backend_class = None
         if flow:
@@ -150,6 +152,7 @@ class Fusesoc:
         edalizer = Edalizer(
             toplevel=core.name,
             flags=flags,
+            variables=variables,
             core_manager=self.cm,
             work_root=work_root,
             export_root=export_root,

--- a/fusesoc/main.py
+++ b/fusesoc/main.py
@@ -327,6 +327,15 @@ def run(fs, args):
         else:
             flags[flag] = True
 
+    variables = {}
+    for variable in args.var:
+        if "=" in variable:
+            var_name, var_value = variable.split("=", 1)
+            variables[var_name] = var_value
+        else:
+            logger.error(f"Invalid variable format: {variable}. Use NAME=VALUE.")
+            exit(1)
+
     fs.cm.db.mapping_set(args.mapping)
 
     if args.lockfile is not None:
@@ -339,7 +348,16 @@ def run(fs, args):
     core = _get_core(fs, args.system)
 
     try:
-        flags = dict(core.get_flags(flags["target"]), **flags)
+        flags = dict(core.get_flags(flags["target"], variables), **flags)
+    except SyntaxError as e:
+        logger.error(str(e))
+        exit(1)
+    except RuntimeError as e:
+        logger.error(str(e))
+        exit(1)
+
+    try:
+        variables = dict(core.get_variables(flags["target"]), **variables)
     except SyntaxError as e:
         logger.error(str(e))
         exit(1)
@@ -349,9 +367,9 @@ def run(fs, args):
 
     # Unconditionally clean out the work root on fresh builds
     # if we use the old tool API or clean flag is set
-    if do_configure and (not core.get_flow(flags) or args.clean):
+    if do_configure and (not core.get_flow(flags, variables) or args.clean):
         try:
-            prepare_work_root(fs.get_work_root(core, flags))
+            prepare_work_root(fs.get_work_root(core, flags, variables))
         except RuntimeError as e:
             logger.error(e)
             exit(1)
@@ -359,7 +377,7 @@ def run(fs, args):
     # Frontend/backend separation
 
     try:
-        edam_file, backend = fs.get_backend(core, flags, args.backendargs)
+        edam_file, backend = fs.get_backend(core, flags, variables, args.backendargs)
 
     except RuntimeError as e:
         logger.error(str(e))
@@ -684,6 +702,12 @@ def get_parser():
     parser_run.add_argument(
         "--flag",
         help="Set custom use flags. Can be specified multiple times",
+        action="append",
+        default=[],
+    )
+    parser_run.add_argument(
+        "--var",
+        help="Set custom variables. Can be specified multiple times",
         action="append",
         default=[],
     )

--- a/tests/capi2_cores/misc/variables.core
+++ b/tests/capi2_cores/misc/variables.core
@@ -1,0 +1,85 @@
+CAPI=2:
+# Copyright FuseSoC contributors
+# Licensed under the 2-Clause BSD License, see LICENSE for details.
+# SPDX-License-Identifier: BSD-2-Clause
+
+name: ::variables:0
+
+generate:
+  generate_with_vars:
+    generator: generator1
+    parameters:
+      PARAM1: $WIDTH
+
+filesets:
+  default:
+    depend:
+      - generators
+  fs_with_dep_vars:
+    depend:
+      - $DEP_VENDOR:$DEP_LIB:$DEP_NAME:$DEP_VERSION
+  fs_with_file_vars:
+    files:
+      - $FILENAME
+    file_type: verilogSource
+  fs_with_downstream_vars:
+    depend:
+        - ::variables_downstream:0
+
+targets:
+  novars: {}
+  emptyvars:
+    variables: {}
+  multiple_vars:
+    variables:
+      var1: "2"
+      var2: blue
+      var3: "false"
+  var_with_gen:
+    filesets:
+      - default
+    variables:
+      WIDTH: "8"
+    generate:
+      - generate_with_vars
+  var_with_params:
+    variables:
+      INTPARAM: "10"
+      STRPARAM: "hello"
+      REALPARAM: "1.61803"
+    parameters:
+      - INTPARAM=$INTPARAM
+      - STRPARAM=$STRPARAM
+      - REALPARAM=$REALPARAM
+  var_with_deps:
+    filesets:
+      - fs_with_dep_vars
+    variables:
+      DEP_VENDOR: ""
+      DEP_LIB: "used"
+      DEP_NAME: "core"
+      DEP_VERSION: "2.0"
+  var_with_files:
+    filesets:
+      - fs_with_file_vars
+    variables:
+      FILENAME: "test.v"
+  var_with_downstream_var:
+    variables:
+      WIDTH_DOWNSTREAM: "32"
+    filesets:
+      - fs_with_downstream_vars
+
+parameters:
+  INTPARAM:
+    datatype: int
+    paramtype: vlogparam
+    default: 4
+  STRPARAM:
+    datatype: str
+    paramtype: vlogparam
+    default: default_string
+  REALPARAM:
+    datatype: real
+    paramtype: vlogparam
+    default: 2.71828

--- a/tests/capi2_cores/misc/variables_downstream.core
+++ b/tests/capi2_cores/misc/variables_downstream.core
@@ -1,0 +1,26 @@
+CAPI=2:
+# Copyright FuseSoC contributors
+# Licensed under the 2-Clause BSD License, see LICENSE for details.
+# SPDX-License-Identifier: BSD-2-Clause
+
+name: ::variables_downstream:0
+
+generate:
+  generate_with_vars_downstream:
+    generator: generator1
+    parameters:
+      PARAM1: $WIDTH_DOWNSTREAM
+
+filesets:
+  default:
+    depend:
+      - generators
+
+targets:
+  default:
+    filesets:
+      - default
+    variables:
+      WIDTH_DOWNSTREAM: "16"
+    generate:
+      - generate_with_vars_downstream

--- a/tests/test_capi2.py
+++ b/tests/test_capi2.py
@@ -155,22 +155,22 @@ def test_capi2_append():
     flags = {"is_toplevel": True}
 
     flags["target"] = "no_fs_no_fsappend"
-    result = [x["name"] for x in core.get_files(flags)]
+    result = [x["name"] for x in core.get_files(flags, {})]
     expected = []
     assert expected == result
 
     flags["target"] = "no_fs_fsappend"
-    result = [x["name"] for x in core.get_files(flags)]
+    result = [x["name"] for x in core.get_files(flags, {})]
     expected = ["file3", "file4"]
     assert expected == result
 
     flags["target"] = "fs_no_fsappend"
-    result = [x["name"] for x in core.get_files(flags)]
+    result = [x["name"] for x in core.get_files(flags, {})]
     expected = ["file1", "file2"]
     assert expected == result
 
     flags["target"] = "fs_fsappend"
-    result = [x["name"] for x in core.get_files(flags)]
+    result = [x["name"] for x in core.get_files(flags, {})]
     expected = ["file1", "file2", "file3", "file4"]
     assert expected == result
 
@@ -184,7 +184,7 @@ def test_capi2_get_depends():
         Core2Parser(), os.path.join(tests_dir, "capi2_cores", "misc", "depends.core")
     )
     flags = {}
-    result = core.get_depends(flags)
+    result = core.get_depends(flags, {})
 
     expected = [
         Vlnv("unversioned"),
@@ -255,14 +255,14 @@ def test_capi2_get_files():
     ]
 
     flags = {"tool": "icarus"}
-    result = core.get_files(flags)
+    result = core.get_files(flags, {})
 
     assert expected == result
 
     core_file = os.path.join(tests_dir, "capi2_cores", "misc", "fileattrs.core")
     core = Core(Core2Parser(), core_file)
     flags = {"is_toplevel": True, "target": "defines"}
-    result = core.get_files(flags)
+    result = core.get_files(flags, {})
     expected = [
         {"name": "hasdefines", "define": {"key1": "value1", "key2": "value2"}},
         {
@@ -288,10 +288,10 @@ def test_capi2_get_filters():
     from fusesoc.core import Core
 
     core = Core(Core2Parser(), os.path.join(cores_dir, "filters.core"))
-    assert [] == core.get_filters({"is_toplevel": True, "target": "nofilters"})
-    assert [] == core.get_filters({"is_toplevel": True, "target": "emptyfilters"})
+    assert [] == core.get_filters({"is_toplevel": True, "target": "nofilters"}, {})
+    assert [] == core.get_filters({"is_toplevel": True, "target": "emptyfilters"}, {})
     assert ["corefilter1", "corefilter2"] == core.get_filters(
-        {"is_toplevel": True, "target": "filters"}
+        {"is_toplevel": True, "target": "filters"}, {}
     )
 
 
@@ -302,16 +302,16 @@ def test_capi2_get_flags():
     core = Core(Core2Parser(), os.path.join(cores_dir, "flags.core"))
 
     with pytest.raises(RuntimeError) as e:
-        core.get_flags("bad_target")
+        core.get_flags("bad_target", {})
     assert "::flags:0' has no target 'bad_target'" in str(e.value)
-    assert {} == core.get_flags("noflags")
-    assert {} == core.get_flags("emptyflags")
-    assert {"tool": "mytool"} == core.get_flags("emptyflagstool")
+    assert {} == core.get_flags("noflags", {})
+    assert {} == core.get_flags("emptyflags", {})
+    assert {"tool": "mytool"} == core.get_flags("emptyflagstool", {})
     expected = {"flag1": False, "flag2": True, "flag3": True}
-    assert expected == core.get_flags("allflags")
+    assert expected == core.get_flags("allflags", {})
     expected["tool"] = "mytool"
     expected.pop("flag3")
-    assert expected == core.get_flags("allflagstool")
+    assert expected == core.get_flags("allflagstool", {})
 
 
 def test_capi2_get_generators():
@@ -381,15 +381,15 @@ def test_capi2_get_parameters():
     flags = {"is_toplevel": True}
     expected = {"param1": param1}
 
-    assert expected == core.get_parameters(flags)
+    assert expected == core.get_parameters(flags, {})
 
     flags["target"] = "noparameters"
     expected = {}
-    assert expected == core.get_parameters(flags)
+    assert expected == core.get_parameters(flags, {})
 
     flags["target"] = "nonexistant"
     with pytest.raises(SyntaxError) as excinfo:
-        core.get_parameters(flags)
+        core.get_parameters(flags, {})
     assert (
         "Parameter 'idontexist', requested by target 'nonexistant', was not found"
         in str(excinfo.value)
@@ -397,7 +397,7 @@ def test_capi2_get_parameters():
 
     flags["target"] = "multiparameters"
     expected = {"param1": param1, "param2": param2}
-    assert expected == core.get_parameters(flags)
+    assert expected == core.get_parameters(flags, {})
 
     flags["target"] = "use_flags"
     expected = {
@@ -405,14 +405,14 @@ def test_capi2_get_parameters():
         "condparamtype": {"datatype": "str", "paramtype": "vlogparam"},
     }
 
-    assert expected == core.get_parameters(flags)
+    assert expected == core.get_parameters(flags, {})
 
     flags["tool"] = "icarus"
     expected = {
         "param1": param1,
         "condparamtype": {"datatype": "str", "paramtype": "plusarg"},
     }
-    assert expected == core.get_parameters(flags)
+    assert expected == core.get_parameters(flags, {})
 
     flags["target"] = "types"
     expected = {
@@ -422,7 +422,7 @@ def test_capi2_get_parameters():
         "booltrue": booltrue,
         "realpi": realpi,
     }
-    result = core.get_parameters(flags)
+    result = core.get_parameters(flags, {})
     assert expected == result
     assert isinstance(result["param2"]["datatype"], str)
     assert isinstance(result["param2"]["default"], str)
@@ -436,7 +436,7 @@ def test_capi2_get_parameters():
     flags["target"] = "empty"
     expected = {"int0": int0, "emptystr": emptystr}
 
-    assert expected == core.get_parameters(flags)
+    assert expected == core.get_parameters(flags, {})
 
     flags["target"] = "override"
     param1["default"] = "def"
@@ -453,7 +453,7 @@ def test_capi2_get_parameters():
         "booltrue": booltrue,
         "realpi": realpi,
     }
-    assert expected == core.get_parameters(flags)
+    assert expected == core.get_parameters(flags, {})
 
 
 def test_capi2_get_scripts():
@@ -495,15 +495,15 @@ def test_capi2_get_scripts():
 
     flags = {"is_toplevel": True}
     expected = {"pre_build": [simple1]}
-    assert expected == core.get_scripts("my_files_root", flags)
+    assert expected == core.get_scripts("my_files_root", flags, {})
 
     flags["target"] = "nohooks"
     expected = {}
-    assert expected == core.get_scripts("my_files_root", flags)
+    assert expected == core.get_scripts("my_files_root", flags, {})
 
     flags["target"] = "nonexistant"
     with pytest.raises(SyntaxError) as excinfo:
-        core.get_scripts("", flags)
+        core.get_scripts("", flags, {})
     assert (
         "Script 'idontexist', requested by target 'nonexistant', was not found"
         in str(excinfo.value)
@@ -516,19 +516,19 @@ def test_capi2_get_scripts():
         "pre_run": [simple3],
         "post_run": [simple4],
     }
-    assert expected == core.get_scripts("my_files_root", flags)
+    assert expected == core.get_scripts("my_files_root", flags, {})
 
     flags["target"] = "multihooks"
     expected = {"pre_run": [simple1, with_env, multi_cmd]}
-    assert expected == core.get_scripts("my_files_root", flags)
+    assert expected == core.get_scripts("my_files_root", flags, {})
 
     flags["target"] = "use_flags"
     expected = {"post_run": [simple2]}
-    assert expected == core.get_scripts("my_files_root", flags)
+    assert expected == core.get_scripts("my_files_root", flags, {})
 
     flags["tool"] = "icarus"
     expected = {"post_run": [simple1]}
-    assert expected == core.get_scripts("my_files_root", flags)
+    assert expected == core.get_scripts("my_files_root", flags, {})
 
 
 def test_capi2_get_tool_options():
@@ -539,22 +539,22 @@ def test_capi2_get_tool_options():
     core = Core(Core2Parser(), core_file)
 
     with pytest.raises(KeyError):
-        core.get_tool_options({})
+        core.get_tool_options({}, {})
 
-    assert {} == core.get_tool_options({"tool": "icarus"})
+    assert {} == core.get_tool_options({"tool": "icarus"}, {})
     flags = {"target": "target_with_tool_options", "is_toplevel": True}
 
     flags["tool"] = "icarus"
     expected = {"iverilog_options": ["a", "few", "options"]}
-    assert expected == core.get_tool_options(flags)
+    assert expected == core.get_tool_options(flags, {})
 
     flags["tool"] = "vivado"
     expected = {"part": "xc7a35tcsg324-1"}
-    assert expected == core.get_tool_options(flags)
+    assert expected == core.get_tool_options(flags, {})
 
     flags["tool"] = "invalid"
     expected = {}
-    assert expected == core.get_tool_options(flags)
+    assert expected == core.get_tool_options(flags, {})
 
 
 def test_capi2_get_toplevel():
@@ -566,13 +566,13 @@ def test_capi2_get_toplevel():
 
     flags = {"target": "no_toplevel"}
     with pytest.raises(SyntaxError):
-        core.get_toplevel(flags)
+        core.get_toplevel(flags, {})
 
     flags = {"target": "str_toplevel"}
-    assert "toplevel_as_string" == core.get_toplevel(flags)
+    assert "toplevel_as_string" == core.get_toplevel(flags, {})
 
     flags = {"target": "list_toplevel"}
-    assert "toplevel as list" == core.get_toplevel(flags)
+    assert "toplevel as list" == core.get_toplevel(flags, {})
 
 
 def test_capi2_get_ttptttg():
@@ -614,21 +614,21 @@ def test_capi2_get_ttptttg():
             "config": {"file_in_param1": "file_cachetest"},
         },
     ]
-    assert expected == core.get_ttptttg(flags)
+    assert expected == core.get_ttptttg(flags, {})
 
     flags["target"] = "nogenerate"
-    assert [] == core.get_ttptttg(flags)
+    assert [] == core.get_ttptttg(flags, {})
 
     flags["target"] = "invalid_generate"
     with pytest.raises(SyntaxError) as excinfo:
-        core.get_ttptttg(flags)
+        core.get_ttptttg(flags, {})
     assert (
         "Generator instance 'idontexist', requested by target 'invalid_generate', was not found"
         in str(excinfo.value)
     )
 
     flags["target"] = "invalid_target"
-    assert [] == core.get_ttptttg(flags)
+    assert [] == core.get_ttptttg(flags, {})
 
 
 def test_capi2_get_vpi():
@@ -648,9 +648,9 @@ def test_capi2_get_vpi():
         {"src_files": ["f4"], "include_dirs": [], "libs": [], "name": "vpi2"},
     ]
 
-    assert [] == core.get_vpi({"is_toplevel": True, "target": "invalid"})
-    assert expected == core.get_vpi({"is_toplevel": True})
-    assert expected == core.get_vpi({"is_toplevel": False})
+    assert [] == core.get_vpi({"is_toplevel": True, "target": "invalid"}, {})
+    assert expected == core.get_vpi({"is_toplevel": True}, {})
+    assert expected == core.get_vpi({"is_toplevel": False}, {})
 
 
 def test_capi2_info():
@@ -819,3 +819,127 @@ def test_inheritance():
 
     capi2_data = parser.read(core_file)
     assert expected == capi2_data
+
+
+def test_variables_local():
+    import os
+
+    from fusesoc.capi2.coreparser import Core2Parser
+    from fusesoc.core import Core
+
+    core_file = os.path.join(tests_dir, "capi2_cores", "misc", "variables.core")
+    core = Core(Core2Parser(), core_file)
+
+    # Test variable section parsing
+    variables = core.get_variables("multiple_vars")
+    expected_vars = {"var1": "2", "var2": "blue", "var3": "false"}
+    assert expected_vars == variables
+
+    # Test no variables not erroring
+    no_vars = core.get_variables("novars")
+    assert {} == no_vars
+
+    # Test generator with variable substitution
+    var_with_gen_variables = core.get_variables("var_with_gen")
+    gen_with_vars = core.get_ttptttg(
+        {"is_toplevel": True, "target": "var_with_gen"}, var_with_gen_variables
+    )
+    expected_gen = [
+        {
+            "name": "generate_with_vars",
+            "generator": "generator1",
+            "config": {"PARAM1": "8"},
+            "pos": "append",
+        },
+    ]
+    assert expected_gen == gen_with_vars
+
+    # Test Paramters with Variable Substitution
+    var_with_param_variables = core.get_variables("var_with_params")
+    params_with_vars = core.get_parameters(
+        {"is_toplevel": True, "target": "var_with_params"}, {}, var_with_param_variables
+    )
+    expected_params = {
+        "INTPARAM": {
+            "datatype": "int",
+            "default": 10,
+            "paramtype": "vlogparam",
+        },
+        "STRPARAM": {
+            "datatype": "str",
+            "default": "hello",
+            "paramtype": "vlogparam",
+        },
+        "REALPARAM": {
+            "datatype": "real",
+            "default": 1.61803,
+            "paramtype": "vlogparam",
+        },
+    }
+    assert expected_params == params_with_vars
+
+    # Test Dependencies with Variable Substitution
+    var_with_dep_variables = core.get_variables("var_with_deps")
+    deps_with_vars = core.get_depends(
+        {"is_toplevel": True, "target": "var_with_deps"}, var_with_dep_variables
+    )
+    assert len(deps_with_vars) == 1
+    dep = deps_with_vars[0]
+    assert str(dep) == ":used:core:2.0"
+
+    # Test Files with Variable Substitution
+    var_with_file_variables = core.get_variables("var_with_files")
+    files_with_vars = core.get_files(
+        {"is_toplevel": True, "target": "var_with_files"}, var_with_file_variables
+    )
+    assert len(files_with_vars) == 1
+    assert files_with_vars[0]["name"] == "test.v"
+    assert files_with_vars[0]["file_type"] == "verilogSource"
+
+    # Test Target Which Relies on Downstream Variables Resolving in Generator
+    # Test Target Which Relies on Downstream Variables Resolving in Generator
+    vars_for_downstream = core.get_variables("var_with_downstream_var")
+
+    # Load the downstream core that is a dependency
+    downstream_core_file = os.path.join(
+        tests_dir, "capi2_cores", "misc", "variables_downstream.core"
+    )
+    downstream_core = Core(Core2Parser(), downstream_core_file)
+
+    # Get the generators from the downstream core's default target using the upstream variables
+    # The upstream target defines WIDTH_DOWNSTREAM="32" which should override the downstream's default of "16"
+    gen_from_downstream = downstream_core.get_ttptttg(
+        {"is_toplevel": True, "target": "default"},
+        vars_for_downstream,
+    )
+
+    expected_gen_downstream = [
+        {
+            "name": "generate_with_vars_downstream",
+            "generator": "generator1",
+            "config": {"PARAM1": "32"},
+            "pos": "append",
+        },
+    ]
+    # Verify that the downstream core's generator uses the upstream variable value
+    assert expected_gen_downstream == gen_from_downstream
+
+    # Test negative case: downstream core with its own default variables
+    # The downstream's own default is WIDTH_DOWNSTREAM="16", which should NOT be overridden
+    # when we explicitly use the downstream's own variables
+    downstream_default_vars = downstream_core.get_variables("default")
+    gen_from_downstream_with_default = downstream_core.get_ttptttg(
+        {"is_toplevel": True, "target": "default"},
+        downstream_default_vars,
+    )
+
+    expected_gen_downstream_default = [
+        {
+            "name": "generate_with_vars_downstream",
+            "generator": "generator1",
+            "config": {"PARAM1": "16"},
+            "pos": "append",
+        },
+    ]
+    # Verify that the downstream core's generator uses its own default value when no override is provided
+    assert expected_gen_downstream_default == gen_from_downstream_with_default

--- a/tests/test_coremanager.py
+++ b/tests/test_coremanager.py
@@ -82,6 +82,7 @@ def test_deptree(tmp_path):
     edalizer = Edalizer(
         toplevel=root_core.name,
         flags=flags,
+        variables={},
         work_root=work_root,
         core_manager=cm,
     )
@@ -144,6 +145,7 @@ def test_copyto():
     edalizer = Edalizer(
         toplevel=core.name,
         flags=flags,
+        variables={},
         core_manager=cm,
         work_root=work_root,
         export_root=None,
@@ -200,6 +202,7 @@ def test_export():
     edalizer = Edalizer(
         toplevel=core.name,
         flags=flags,
+        variables={},
         core_manager=cm,
         work_root=work_root,
         export_root=export_root,
@@ -275,6 +278,7 @@ def test_virtual():
         edalizer = Edalizer(
             toplevel=root_core.name,
             flags=flags,
+            variables={},
             core_manager=cm,
             work_root=work_root,
         )
@@ -315,6 +319,7 @@ def test_virtual_conflict():
     edalizer = Edalizer(
         toplevel=root_core.name,
         flags=flags,
+        variables={},
         core_manager=cm,
         work_root=work_root,
     )
@@ -352,6 +357,7 @@ def test_virtual_non_deterministic_virtual(caplog):
     edalizer = Edalizer(
         toplevel=root_core.name,
         flags=flags,
+        variables={},
         core_manager=cm,
         work_root=work_root,
     )
@@ -498,6 +504,7 @@ def test_lockfile(caplog):
     edalizer = Edalizer(
         toplevel=root_core.name,
         flags=flags,
+        variables={},
         core_manager=cm,
         work_root=work_root,
     )
@@ -551,6 +558,7 @@ def test_lockfile_partial_warning(caplog):
     edalizer = Edalizer(
         toplevel=root_core.name,
         flags=flags,
+        variables={},
         core_manager=cm,
         work_root=work_root,
     )
@@ -606,6 +614,7 @@ def test_lockfile_version_warning(caplog):
     edalizer = Edalizer(
         toplevel=root_core.name,
         flags=flags,
+        variables={},
         core_manager=cm,
         work_root=work_root,
     )
@@ -657,6 +666,7 @@ def test_lockfile_no_file(caplog):
     edalizer = Edalizer(
         toplevel=root_core.name,
         flags=flags,
+        variables={},
         core_manager=cm,
         work_root=work_root,
     )
@@ -712,6 +722,7 @@ def test_lockfile_no_file_create(caplog):
     edalizer = Edalizer(
         toplevel=root_core.name,
         flags=flags,
+        variables={},
         core_manager=cm,
         work_root=work_root,
     )

--- a/tests/test_edalizer.py
+++ b/tests/test_edalizer.py
@@ -39,6 +39,7 @@ def test_apply_filters(caplog):
     edalizer = Edalizer(
         toplevel=None,
         flags=None,
+        variables=None,
         work_root=None,
         core_manager=None,
     )
@@ -103,6 +104,7 @@ def test_tool_or_flow():
     edam = Edalizer(
         toplevel=core.name,
         flags={"target": "nothing"},
+        variables={},
         core_manager=cm,
         work_root=".",
     ).run()
@@ -111,6 +113,7 @@ def test_tool_or_flow():
     edam = Edalizer(
         toplevel=core.name,
         flags={"target": "flowonly"},
+        variables={},
         core_manager=cm,
         work_root=".",
     ).run()
@@ -119,6 +122,7 @@ def test_tool_or_flow():
     edam = Edalizer(
         toplevel=core.name,
         flags={"target": "emptyflowoptions"},
+        variables={},
         core_manager=cm,
         work_root=".",
     ).run()
@@ -127,6 +131,7 @@ def test_tool_or_flow():
     edam = Edalizer(
         toplevel=core.name,
         flags={"target": "toolonly"},
+        variables={},
         core_manager=cm,
         work_root=".",
     ).run()
@@ -135,6 +140,7 @@ def test_tool_or_flow():
     edam = Edalizer(
         toplevel=core.name,
         flags={"target": "flowandtool"},
+        variables={},
         core_manager=cm,
         work_root=".",
     ).run()
@@ -143,6 +149,7 @@ def test_tool_or_flow():
     edam = Edalizer(
         toplevel=core.name,
         flags={"target": "flowoptions"},
+        variables={},
         core_manager=cm,
         work_root=".",
     ).run()
@@ -181,6 +188,7 @@ def test_generators():
     edalizer = Edalizer(
         toplevel=core.name,
         flags={"tool": "icarus"},
+        variables={},
         core_manager=cm,
         work_root=build_root / "work",
         export_root=export_root,


### PR DESCRIPTION
# CAPI2 Variables 
Introducing flag-like variables feature discussed originally in #675

## High Level Feature Description: 

Add the ability to assign CAPI2 entries to a variable, denoted by a string which starts with ``$``
Globally resolve variables either from defaults set in a target, or from CLI arguments 

## Change Details: 
* Add ``variables`` section to ``target`` which allows for the definition of int, string, or bool variables which can be defined as key-value pairs
* Add support for new meta-character, ``$``, which can be used in a manner similar to bash variables wherever a flag ternary operation can currently be used 
* Add new cli for ``fusesoc run``, ``--var key=value`` , which can supplement target held variables
* Add testing to ensure functionality of the variables infrastructure
* Add variables to build_system documentation 

## Design Decisions
* Add variables as coequal to flags instead of as redesigning flags as a data class to prevent any major re-writes of the flags system, although unifying is appealing at a later time
* Intentionally did not fuse them with parameters because of parameters isolation to use in the backend rather than the front end

## Pain Points Solved
* ** Allows for upstream control of downstream generators**
* Allows for less complex flag ternary trees downstream
* Simplifies duplicated tool options (e.g. same command passed to vlogan/vhdlan and vcs in vcs simulations)
* Gives end users more flexibility in implementing their vision

## Considered Extensions 
* Allow for inline variable defaults (e.g. my_key: $my_value:=<default_value>)


The implementation was intentionally simple, happy to iterate on it more if there's specific pain points that can be solved in this change. 