### PR TITLE
Fix "fusesoc tool list" with edalize 0.6.2+

### DIFF
--- a/fusesoc/main.py
+++ b/fusesoc/main.py
@@ -216,19 +216,39 @@ def list_cores(fs, args):
 
 
 def list_tools(fs, args):
-    from edalize.edatool import get_edatool, walk_tool_packages
+    import edalize.edatool
+    if hasattr(edalize.edatool, "get_edatool_map"):
+        # edalize>=0.6.2
+        from edalize.edatool import get_edatool_map
+        NON_TOOLS = ["edatool"] # edalize reports this abstract class as a tool
+        tools = get_edatool_map()
+        maxlen = max(map(len, tools.keys()))
 
-    _tp = list(walk_tool_packages())
-    maxlen = max(map(len, _tp))
+        for name, tool in tools.items():
+            if name in NON_TOOLS:
+                continue
+            try:
+                desc = tool.tool_class.get_doc(0)["description"]
+                print(f"{name:{maxlen}}: {desc}")
+            # Ignore any misbehaving backends
+            except Exception:
+                pass
+    else:
+        # edalize<=0.6.1
+        from edalize.edatool import get_edatool, walk_tool_packages
 
-    for tool_name in _tp:
-        try:
-            tool_class = get_edatool(tool_name)
-            desc = tool_class.get_doc(0)["description"]
-            print(f"{tool_name:{maxlen}} : {desc}")
-        # Ignore any misbehaving backends
-        except Exception:
-            pass
+        _tp = list(walk_tool_packages())
+        maxlen = max(map(len, _tp))
+
+        for tool_name in _tp:
+            try:
+                tool_class = get_edatool(tool_name)
+                desc = tool_class.get_doc(0)["description"]
+                print(f"{tool_name:{maxlen}} : {desc}")
+            # Ignore any misbehaving backends
+            except Exception:
+                pass
+
 
 
 def gen_list(fs, args):


### PR DESCRIPTION
Edalize removed the methods previously used to list the tools (`walk_tool_packages`). Use the new methods when present.