### PR TITLE
Run parse_args before apply_filters in get_backend

### DIFF
--- a/fusesoc/fusesoc.py
+++ b/fusesoc/fusesoc.py
@@ -162,8 +162,8 @@ class Fusesoc:
             edalizer.run()
             edalizer.export()
             Path(work_root).mkdir(parents=True, exist_ok=True)
-            edalizer.apply_filters(self.config.filters)
             edalizer.parse_args(backend_class, backendargs)
+            edalizer.apply_filters(self.config.filters)
         except SyntaxError as e:
             raise RuntimeError(e.msg)
         except RuntimeError as e:


### PR DESCRIPTION
## Summary

- Swap `parse_args` and `apply_filters` ordering in `get_backend()` so that EDAM filters see fully resolved command-line parameter overrides

`parse_args` resolves command-line parameter overrides (e.g. `--PARAM=val`) into the EDAM `parameters` dict. When `apply_filters` runs first, filters that read `vlogparam` defaults (such as elaboration-based lowering filters) only see the `.core` file defaults, not the user's command-line overrides.

## Test plan

- [x] Existing `test_edalizer.py` tests pass (filter behaviour unchanged)
- [x] Verify with a flow that uses `--PARAM=val` overrides and an EDAM filter that reads parameter values