### PR TITLE
Fix #683: stringify non-bool flag values

### DIFF
--- a/fusesoc/capi2/exprs.py
+++ b/fusesoc/capi2/exprs.py
@@ -191,7 +191,7 @@ class Exprs:
             if v is True:
                 ret.append(k)
             elif v not in [False, None]:
-                ret.append(k + "_" + v)
+                ret.append(k + "_" + str(v))
         return set(ret)
 
     def expand(self, flags):

--- a/tests/test_exprs.py
+++ b/tests/test_exprs.py
@@ -52,3 +52,8 @@ def test_expand():
     check_expand("mode_foo ? (a)", {"mode": "bar"}, "")
     check_expand("!mode_foo ? (a)", {"mode": "foo"}, "")
     check_expand("!mode_foo ? (a)", {"mode": "bar"}, "a")
+
+    # Numeric flag values should be stringified, not crash
+    check_expand("blah_1234 ? (a)", {"blah": 1234}, "a")
+    check_expand("blah_1234 ? (a)", {"blah": 5678}, "")
+    check_expand("!blah_1234 ? (a)", {"blah": 1234}, "")


### PR DESCRIPTION
## Problem
Fixes https://github.com/olofk/fusesoc/issues/683.

A numeric flag value (e.g. `flags: { blah: 1234 }` in a target — which YAML parses as int) crashed `Exprs._flags_to_flag_defs` with a raw Python `TypeError: can only concatenate str (not "int") to str`, with no useful context for the user.

## Solution
The CAPI2 schema already allows `any_type` (including `number`) for flag values, so coerce anything that isn't a bool/`None` to its `str()` representation before joining it with the flag key. This makes `flags: { blah: 1234 }` behave like `flags: { blah: "1234" }`, defining the flag `blah_1234`.

## Test plan
- [x] New regression cases in `tests/test_exprs.py` covering numeric flag values
- [x] Full pytest suite green locally
- [x] `pre-commit run -a` clean
