### PR TITLE
Fix #749: reject illegal characters in VLNV names

### DIFF
--- a/fusesoc/vlnv.py
+++ b/fusesoc/vlnv.py
@@ -3,7 +3,10 @@
 # SPDX-License-Identifier: BSD-2-Clause
 
 import copy
+import re
 from functools import total_ordering
+
+_VLNV_PART_RE = re.compile(r"^[A-Za-z0-9_.-]*$")
 
 
 @total_ordering
@@ -95,6 +98,14 @@ class Vlnv:
             # No version specifier means any version i.e. >=0
             self.version = "0"
             self.relation = default_relation
+
+        for field in ("vendor", "library", "name", "version"):
+            value = getattr(self, field)
+            if not _VLNV_PART_RE.match(value):
+                raise SyntaxError(
+                    "Illegal character in core name '{}': {} '{}' may only "
+                    "contain alphanumerics, '.', '-', and '_'".format(s, field, value)
+                )
 
         # Create sanitized name
         self.sanitized_name = str(self).lstrip(":").replace(":", "_")

--- a/tests/test_vlnv.py
+++ b/tests/test_vlnv.py
@@ -2,6 +2,8 @@
 # Licensed under the 2-Clause BSD License, see LICENSE for details.
 # SPDX-License-Identifier: BSD-2-Clause
 
+import pytest
+
 from fusesoc.vlnv import Vlnv, compare_relation
 
 
@@ -78,6 +80,24 @@ def test_name_version_revision_legacy():
 
 def test_name_revision_legacy():
     assert vlnv_tuple(Vlnv("uart16550-r2")) == ("", "", "uart16550", "0", 2)
+
+
+# Reject names containing characters that downstream parsers cannot handle.
+# Regression tests for https://github.com/olofk/fusesoc/issues/749
+@pytest.mark.parametrize(
+    "bad_name",
+    [
+        "a/b",
+        "::a/b",
+        "vend/or:lib:name",
+        "::a b:0",
+        "::na\tme",
+        "foo*:lib:name:0",
+    ],
+)
+def test_vlnv_rejects_illegal_chars(bad_name):
+    with pytest.raises(SyntaxError, match="Illegal character"):
+        Vlnv(bad_name)
 
 
 def test_vlvn_compare_relation():


### PR DESCRIPTION
## Problem
Fixes https://github.com/olofk/fusesoc/issues/749.

`fusesoc core-info a/b` (and any other command taking a VLNV containing characters like `/` or whitespace) crashed with a multi-frame Python traceback ending in `simplesat.errors.InvalidConstraint`, because the illegal characters made it through `Vlnv` parsing untouched and only blew up later inside simplesat's tokenizer.

## Solution
Validate `vendor`/`library`/`name`/`version` after parsing in `Vlnv.__init__` and raise a clean `SyntaxError` if any of them contain characters outside `[A-Za-z0-9_.-]`. Produces a one-line, actionable error instead of a stack trace pointing into a third-party dependency.

## Test plan
- [x] Parametrised regression test in `tests/test_vlnv.py` covering `/`, whitespace, `*`, etc.
- [x] All existing VLNV tests still pass
- [x] `pre-commit run -a` clean
