### PR TITLE
Fix #646: prefix hook script names with owning core's VLNV

### DIFF
--- a/fusesoc/edalizer.py
+++ b/fusesoc/edalizer.py
@@ -253,8 +253,17 @@ class Edalizer:
             # Extract flow options
             snippet["flow_options"] = core.get_flow_options(_flags)
 
-            # Extract scripts
+            # Extract scripts. Prefix every hook script name with the owning
+            # core's sanitized VLNV: edalize generates one Makefile target per
+            # hook script using its `name`, so two cores defining a script
+            # called `foo` would otherwise produce duplicate targets and only
+            # the last one would run.
             snippet["hooks"] = core.get_scripts(rel_root, _flags)
+            for hook_scripts in snippet["hooks"].values():
+                for script in hook_scripts:
+                    script["name"] = "{}_{}".format(
+                        core.name.sanitized_name, script["name"]
+                    )
 
             _files = []
             for file in core.get_files(_flags):

--- a/tests/capi2_cores/hooks_collision/child.core
+++ b/tests/capi2_cores/hooks_collision/child.core
@@ -1,0 +1,18 @@
+CAPI=2:
+# Copyright FuseSoC contributors
+# Licensed under the 2-Clause BSD License, see LICENSE for details.
+# SPDX-License-Identifier: BSD-2-Clause
+
+name: ::hookcollision-child:0
+filesets:
+  fs:
+    depend: ["::hookcollision-parent:0"]
+scripts:
+  myhook:
+    cmd: [child_cmd]
+targets:
+  default:
+    filesets: [fs]
+    toplevel: unused
+    hooks:
+      pre_build: [myhook]

--- a/tests/capi2_cores/hooks_collision/parent.core
+++ b/tests/capi2_cores/hooks_collision/parent.core
@@ -1,0 +1,14 @@
+CAPI=2:
+# Copyright FuseSoC contributors
+# Licensed under the 2-Clause BSD License, see LICENSE for details.
+# SPDX-License-Identifier: BSD-2-Clause
+
+name: ::hookcollision-parent:0
+scripts:
+  myhook:
+    cmd: [parent_cmd]
+targets:
+  default:
+    toplevel: unused
+    hooks:
+      pre_build: [myhook]

--- a/tests/test_edalizer.py
+++ b/tests/test_edalizer.py
@@ -302,3 +302,39 @@ def test_generators():
         == "generate-testgenerate_with_file_cache_0-f3d9e1e462ef1f7113fafbacd62d6335dd684e69332f75498fb01bfaaa7c11ee"
     )
     shutil.rmtree(core.core_root, ignore_errors=True)
+
+
+def test_hook_script_names_are_unique_per_core():
+    """Two cores with a same-named hook script must produce distinct EDAM
+    hook names so edalize doesn't generate duplicate Makefile targets.
+
+    Regression test for https://github.com/olofk/fusesoc/issues/646
+    """
+    import os
+
+    from fusesoc.config import Config
+    from fusesoc.coremanager import CoreManager
+    from fusesoc.edalizer import Edalizer
+    from fusesoc.librarymanager import Library
+    from fusesoc.vlnv import Vlnv
+
+    tests_dir = os.path.dirname(__file__)
+    cores_dir = os.path.join(tests_dir, "capi2_cores", "hooks_collision")
+
+    cm = CoreManager(Config())
+    cm.add_library(Library("hooks_collision", cores_dir), [])
+
+    child = cm.get_core(Vlnv("::hookcollision-child:0"))
+    edam = Edalizer(
+        toplevel=child.name,
+        flags={"tool": "icarus"},
+        core_manager=cm,
+        work_root=".",
+    ).run()
+
+    pre_build_hooks = edam["hooks"]["pre_build"]
+    assert len(pre_build_hooks) == 2
+    names = [h["name"] for h in pre_build_hooks]
+    assert len(set(names)) == 2, f"hook script names collided: {names}"
+    assert "hookcollision-parent_0_myhook" in names
+    assert "hookcollision-child_0_myhook" in names


### PR DESCRIPTION
## Problem
Fixes https://github.com/olofk/fusesoc/issues/646.

Edalize generates one Makefile target per hook script using the script's `name` field. When two cores in the dependency tree defined a hook script with the same user-facing name (typical when a child core inherits/overrides a hook from a parent), both ended up in the merged EDAM `hooks` list with identical names, so the Makefile got duplicate targets and only the last one was actually run — silently dropping the inherited hook. @olofk confirmed in the issue that the fix needs to be on the FuseSoC side.

## Solution
In `Edalizer.create_edam`, prefix each emitted hook script's `name` with the owning core's `sanitized_name`. `Core.get_scripts` keeps returning the user-facing name unchanged so other call sites and `test_capi2` expectations stay valid; the prefixing happens only at the EDAM emission boundary, where the owning-core context is available.

## Test plan
- [x] New two-core fixture in `tests/capi2_cores/hooks_collision/` and `test_hook_script_names_are_unique_per_core` in `tests/test_edalizer.py`. Verified the test fails without the fix and passes with it.
- [x] Full pytest suite green
- [x] `pre-commit run -a` clean
