### PR TITLE
Fix #700: invalidate provider cache when its config changes

### DIFF
--- a/fusesoc/provider/provider.py
+++ b/fusesoc/provider/provider.py
@@ -2,6 +2,7 @@
 # Licensed under the 2-Clause BSD License, see LICENSE for details.
 # SPDX-License-Identifier: BSD-2-Clause
 
+import json
 import logging
 import os
 import shutil
@@ -11,6 +12,12 @@ from importlib import import_module
 from fusesoc.utils import Launcher
 
 logger = logging.getLogger(__name__)
+
+# File written inside a cached files_root after a successful checkout. Holds a
+# normalised JSON copy of the provider's CAPI2 config so subsequent runs can
+# detect when the user changed e.g. the provider ``version`` and the cache
+# needs to be refreshed.
+_CONFIG_MARKER = ".fusesoc-provider-config.json"
 
 
 def get_provider(name):
@@ -24,6 +31,36 @@ class Provider:
         self.files_root = files_root
         self.cachable = config.get("cachable", "") is not False
         self.patches = config.get("patches", [])
+
+    def _config_marker_path(self):
+        return os.path.join(self.files_root, _CONFIG_MARKER)
+
+    def _config_marker_value(self):
+        # Serialise with sorted keys so logically-equal configs compare equal,
+        # and exclude ``cachable`` since it controls *whether* we cache, not
+        # *what* we cache.
+        comparable = {k: v for k, v in self.config.items() if k != "cachable"}
+        return json.dumps(comparable, sort_keys=True)
+
+    def _read_config_marker(self):
+        try:
+            with open(self._config_marker_path()) as f:
+                return f.read()
+        except OSError:
+            return None
+
+    def _write_config_marker(self):
+        try:
+            with open(self._config_marker_path(), "w") as f:
+                f.write(self._config_marker_value())
+        except OSError as e:
+            # Don't fail the whole fetch over a marker write — we just lose the
+            # cache-invalidation benefit on the next run.
+            logger.warning(
+                "Failed to write provider cache marker {}: {}".format(
+                    self._config_marker_path(), e
+                )
+            )
 
     def clean_cache(self):
         def _make_tree_writable(topdir):
@@ -59,6 +96,11 @@ class Provider:
             )
         if _fetched:
             self._patch()
+        # Always (re-)write the marker after a successful fetch, including
+        # the legacy "downloaded but no marker" case from caches predating
+        # marker support.
+        if self.cachable and os.path.isdir(self.files_root):
+            self._write_config_marker()
 
     def _patch(self):
         for f in self.patches:
@@ -81,5 +123,11 @@ class Provider:
             return "outofdate"
         if not os.path.isdir(self.files_root):
             return "empty"
-        else:
-            return "downloaded"
+        marker = self._read_config_marker()
+        # No marker means the cache was populated by a fusesoc that predates
+        # the marker (or by something else that touched the directory). Stay
+        # backward-compatible: assume the cache is valid; ``fetch()`` will
+        # write a fresh marker so subsequent runs can spot drift.
+        if marker is not None and marker != self._config_marker_value():
+            return "outofdate"
+        return "downloaded"

--- a/tests/test_provider.py
+++ b/tests/test_provider.py
@@ -117,3 +117,80 @@ def test_cachable():
     assert core.cache_status() == "empty"
     core.setup()
     assert core.cache_status() == "downloaded"
+
+
+def test_provider_cache_invalidates_on_config_change(tmp_path):
+    """Changing a field in a core's ``provider`` block (e.g. ``version``)
+    should be detected on the next run so the cache gets refreshed instead
+    of silently serving stale content.
+
+    Regression test for https://github.com/olofk/fusesoc/issues/700.
+    """
+    from fusesoc.provider.provider import Provider
+
+    files_root = tmp_path / "cache"
+    files_root.mkdir()
+    (files_root / "payload").write_text("v1")
+
+    # Initial fetch with version v1
+    p1 = Provider(
+        config={
+            "name": "url",
+            "url": "https://example.invalid/foo.tar",
+            "version": "v1",
+        },
+        core_root=str(tmp_path),
+        files_root=str(files_root),
+    )
+    # Simulate "fetch" having completed by writing the marker manually; we
+    # don't actually want to hit the network in this test.
+    p1._write_config_marker()
+    assert p1.status() == "downloaded"
+
+    # Same config, different Provider instance: still considered downloaded.
+    p_same = Provider(
+        config={
+            "name": "url",
+            "url": "https://example.invalid/foo.tar",
+            "version": "v1",
+        },
+        core_root=str(tmp_path),
+        files_root=str(files_root),
+    )
+    assert p_same.status() == "downloaded"
+
+    # User changes ``version``: cache must now be flagged out-of-date.
+    p_changed = Provider(
+        config={
+            "name": "url",
+            "url": "https://example.invalid/foo.tar",
+            "version": "v2",
+        },
+        core_root=str(tmp_path),
+        files_root=str(files_root),
+    )
+    assert p_changed.status() == "outofdate"
+
+
+def test_provider_legacy_cache_without_marker_is_valid(tmp_path):
+    """Caches populated by an older fusesoc don't have the marker file. Treat
+    them as valid for backward compatibility; the next fetch will create the
+    marker so future drift is detectable.
+    """
+    from fusesoc.provider.provider import Provider
+
+    files_root = tmp_path / "cache"
+    files_root.mkdir()
+    (files_root / "payload").write_text("legacy")
+    # Note: no .fusesoc-provider-config.json marker is written.
+
+    p = Provider(
+        config={
+            "name": "url",
+            "url": "https://example.invalid/foo.tar",
+            "version": "v1",
+        },
+        core_root=str(tmp_path),
+        files_root=str(files_root),
+    )
+    assert p.status() == "downloaded"


### PR DESCRIPTION
## Problem
Fixes https://github.com/olofk/fusesoc/issues/700.

`Provider.status()` only checks whether the cache directory exists on disk. Once a core has been fetched, FuseSoC happily reuses the cached files for every subsequent run, even if the user has since changed the core's `provider:` block — most notably the `version` field. So flipping `version: v1.0.4-rc0` → `version: v1.0.4-rc1` silently keeps building against the rc0 sources, with the only workaround being to bump the core's own VLNV version (which then cascades through dependents).

## Solution
After a successful fetch, write a `.fusesoc-provider-config.json` marker inside the cache directory containing a normalised JSON copy of the provider config. `status()` reads it back on subsequent runs and flags the cache as `outofdate` whenever the current config no longer matches, which then triggers the existing clean-and-refetch path.

Caches written by older FuseSoC don't have the marker; treat those as valid for backward compatibility (no surprise refetch on upgrade) and let the next fetch write a fresh marker so any future drift is caught.

## Test plan
- [x] `test_provider_cache_invalidates_on_config_change` — confirms a changed `version` flips status from `downloaded` to `outofdate`.
- [x] `test_provider_legacy_cache_without_marker_is_valid` — confirms a pre-marker cache is still treated as `downloaded`.
- [x] Existing provider tests (`test_git_provider`, `test_url_provider`, `test_uncachable`, etc.) still pass.
- [x] `pre-commit run -a` clean.
