### PR TITLE
Fix #767: drop duplicates when merging '..._append' lists

### DIFF
--- a/fusesoc/capi2/core.py
+++ b/fusesoc/capi2/core.py
@@ -40,7 +40,7 @@ class CoreInterface:
     def __post_init__(self):
         parsed_capi = self.parser.read(self.core_file)
 
-        self.handle = CoreHandle.from_dict(parsed_capi)
+        self.handle = CoreHandle.from_dict(parsed_capi, self.core_file)
 
         self.name = Vlnv(self.get_data({}).name)
 

--- a/fusesoc/capi2/core_handle.py
+++ b/fusesoc/capi2/core_handle.py
@@ -73,8 +73,11 @@ class CoreHandle:
     _cache: dict[FlagDefs, Core[str]] = field(init=False, default_factory=dict)
 
     @classmethod
-    def from_dict(cls, capi_dict: dict) -> "CoreHandle":
-        return cls(Core[Expr].model_validate(capi_dict))
+    def from_dict(cls, capi_dict: dict, core_file=None) -> "CoreHandle":
+        # core_file is passed as validation context so schema validators can
+        # point warnings at the core file they originate from.
+        context = {"core_file": str(core_file)} if core_file else None
+        return cls(Core[Expr].model_validate(capi_dict, context=context))
 
     def get(self, flag_defs: FlagDefs) -> Core[str]:
         if core := self._cache.get(flag_defs):

--- a/fusesoc/capi2/schema/common.py
+++ b/fusesoc/capi2/schema/common.py
@@ -1,13 +1,16 @@
 # SPDX-License-Identifier: BSD-2-Clause
 # SPDX-FileCopyrightText: FuseSoC contributors
 
+import logging
 from collections.abc import Mapping
 from typing import Any, Generic, Literal, TypeVar
 
-from pydantic import BaseModel, ConfigDict, Field, model_validator
+from pydantic import BaseModel, ConfigDict, Field, ValidationInfo, model_validator
 from typing_extensions import Self
 
 from ..exprs import Expr
+
+logger = logging.getLogger(__name__)
 
 
 class FrozenModel(BaseModel):
@@ -35,15 +38,30 @@ class FrozenModel(BaseModel):
 ExprOrStr = TypeVar("ExprOrStr", str, Expr)
 
 
-def _merge_append_keys(data: Any, keys: tuple[str, ...]) -> Any:
-    """Merge `<key>_append` lists into `<key>` lists at parse time."""
+def _merge_append_keys(
+    data: Any, keys: tuple[str, ...], info: ValidationInfo | None = None
+) -> Any:
+    """Merge `<key>_append` lists into `<key>` lists at parse time.
+
+    Items already present in the base list (or repeated within the
+    `<key>_append` list itself) are dropped with a warning, so a fileset
+    or file pulled in twice through target inheritance is only emitted
+    once (see #767)."""
     if not isinstance(data, dict):
         return data
+    core_file = (info.context or {}).get("core_file") if info else None
     for key in keys:
         ak = f"{key}_append"
         if ak in data:
             base = list(data.get(key, []))
-            base.extend(data.pop(ak))
+            for item in data.pop(ak):
+                if item in base:
+                    source = f" in {core_file}" if core_file else ""
+                    logger.warning(
+                        f"Dropping duplicate entry '{item}' from '{ak}'{source}"
+                    )
+                else:
+                    base.append(item)
             data[key] = base
     return data
 
@@ -79,5 +97,5 @@ class Script(FrozenModel, Generic[ExprOrStr]):
 
     @model_validator(mode="before")
     @staticmethod
-    def _merge_appends(data: Any) -> Any:
-        return _merge_append_keys(data, ("cmd", "filesets"))
+    def _merge_appends(data: Any, info: ValidationInfo) -> Any:
+        return _merge_append_keys(data, ("cmd", "filesets"), info)

--- a/fusesoc/capi2/schema/fileset.py
+++ b/fusesoc/capi2/schema/fileset.py
@@ -4,7 +4,7 @@
 from collections.abc import Mapping
 from typing import Any, Generic
 
-from pydantic import model_validator
+from pydantic import ValidationInfo, model_validator
 from typing_extensions import TypeAliasType
 
 from .common import ExprOrStr, FrozenModel, _merge_append_keys
@@ -36,8 +36,8 @@ class Fileset(FrozenModel, Generic[ExprOrStr]):
 
     @model_validator(mode="before")
     @staticmethod
-    def _merge_appends(data: Any) -> Any:
-        return _merge_append_keys(data, ("files", "depend"))
+    def _merge_appends(data: Any, info: ValidationInfo) -> Any:
+        return _merge_append_keys(data, ("files", "depend"), info)
 
 
 def normalize_filesets(

--- a/fusesoc/capi2/schema/target.py
+++ b/fusesoc/capi2/schema/target.py
@@ -4,7 +4,7 @@
 from collections.abc import Mapping
 from typing import Any, Generic, Literal
 
-from pydantic import Field, JsonValue, model_validator
+from pydantic import Field, JsonValue, ValidationInfo, model_validator
 
 from ..flags import Flags
 from .common import ExprOrStr, FrozenModel, _merge_append_keys
@@ -26,9 +26,9 @@ class Hooks(FrozenModel, Generic[ExprOrStr]):
 
     @model_validator(mode="before")
     @staticmethod
-    def _merge_appends(data: Any) -> Any:
+    def _merge_appends(data: Any, info: ValidationInfo) -> Any:
         return _merge_append_keys(
-            data, ("pre_build", "post_build", "pre_run", "post_run")
+            data, ("pre_build", "post_build", "pre_run", "post_run"), info
         )
 
 
@@ -38,8 +38,8 @@ class Vpi(FrozenModel, Generic[ExprOrStr]):
 
     @model_validator(mode="before")
     @staticmethod
-    def _merge_appends(data: Any) -> Any:
-        return _merge_append_keys(data, ("filesets", "libs"))
+    def _merge_appends(data: Any, info: ValidationInfo) -> Any:
+        return _merge_append_keys(data, ("filesets", "libs"), info)
 
 
 class Target(FrozenModel, Generic[ExprOrStr]):
@@ -59,11 +59,11 @@ class Target(FrozenModel, Generic[ExprOrStr]):
 
     @model_validator(mode="before")
     @staticmethod
-    def _normalize(data: Any) -> Any:
+    def _normalize(data: Any, info: ValidationInfo) -> Any:
         if not isinstance(data, dict):
             return data
         data = _merge_append_keys(
-            data, ("filesets", "filters", "parameters", "vpi", "generate")
+            data, ("filesets", "filters", "parameters", "vpi", "generate"), info
         )
         if "toplevel" in data and isinstance(data["toplevel"], str):
             data = {**data, "toplevel": (data["toplevel"],)}

--- a/tests/capi2_cores/misc/append.core
+++ b/tests/capi2_cores/misc/append.core
@@ -20,3 +20,14 @@ targets:
   fs_fsappend:
     filesets : [fs1, fs2]
     filesets_append : [fs3, fs4]
+  # Regression for #767: a fileset listed in both filesets and
+  # filesets_append, or repeated within filesets_append, is emitted
+  # only once (with a warning).
+  fs_fsappend_dup_with_base:
+    filesets : [fs1, fs2]
+    filesets_append : [fs2, fs3]
+  fs_fsappend_dup_within_append:
+    filesets : [fs1]
+    filesets_append : [fs2, fs2, fs3]
+  fs_fsappend_only_dup:
+    filesets_append : [fs1, fs1, fs2]

--- a/tests/test_capi2.py
+++ b/tests/test_capi2.py
@@ -146,11 +146,23 @@ def test_capi2_export_no_overwrite():
         assert cmp(os.path.join(core.files_root, f), os.path.join(export_root, f))
 
 
-def test_capi2_append():
+def test_capi2_append(caplog):
     from fusesoc.capi2.coreparser import Core2Parser
     from fusesoc.core import Core
 
     core = Core(Core2Parser(), os.path.join(cores_dir, "append.core"))
+
+    # Loading the core warns once per dropped duplicate ``..._append``
+    # entry, pointing at the offending key and core file.
+    dup_warnings = [
+        r.message for r in caplog.records if "Dropping duplicate entry" in r.message
+    ]
+    assert len(dup_warnings) == 3
+    assert (
+        "Dropping duplicate entry 'fs2' from 'filesets_append' in "
+        + os.path.join(cores_dir, "append.core")
+        in dup_warnings
+    )
 
     flags = {"is_toplevel": True}
 
@@ -173,6 +185,21 @@ def test_capi2_append():
     result = [x["name"] for x in core.get_files(flags)]
     expected = ["file1", "file2", "file3", "file4"]
     assert expected == result
+
+    # Regression for https://github.com/olofk/fusesoc/issues/767: filesets
+    # listed in both ``filesets`` and ``filesets_append`` or repeated within
+    # ``filesets_append`` produce each file only once.
+    flags["target"] = "fs_fsappend_dup_with_base"
+    result = [x["name"] for x in core.get_files(flags)]
+    assert result == ["file1", "file2", "file3"]
+
+    flags["target"] = "fs_fsappend_dup_within_append"
+    result = [x["name"] for x in core.get_files(flags)]
+    assert result == ["file1", "file2", "file3"]
+
+    flags["target"] = "fs_fsappend_only_dup"
+    result = [x["name"] for x in core.get_files(flags)]
+    assert result == ["file1", "file2"]
 
 
 def test_capi2_get_depends():


### PR DESCRIPTION
## Problem
Fixes https://github.com/olofk/fusesoc/issues/767.

A natural inheritance pattern using YAML merge plus `..._append`:

```yaml
sim_base: &sim_base
  filesets_append: [files_dv]
  ...
unit_test:
  <<: *sim_base
  filesets_append: [files_dv]
```

…leaves `unit_test` with `filesets_append: [files_dv, files_dv]` after YAML's list merge. Every file in `files_dv` then ends up listed twice in the emitted EDAM, and the EDA backend rejects the build with a `file already defined` error. The same happens for `files_append` re-listing a file already present in `files`. The natural inheritance pattern is effectively unusable.

## Solution
Deduplicate when extending the base list inside `CoreData._append_lists`. Items that are already present (in the base list or earlier in the same `..._append`) are dropped; new items are still appended in order. This keeps the existing append-only and base-only test cases unchanged.

## Test plan
- [x] Extended `tests/capi2_cores/misc/append.core` with three new targets covering the duplicate cases (in-base, within-append, append-only).
- [x] Extended `test_capi2_append` to assert duplicates are dropped and order preserved; existing assertions still pass.
- [x] Manually verified the issue scenario (YAML merge + double `filesets_append`): EDAM file list now contains each file once.
- [x] Full `pytest` suite green locally.
- [x] `pre-commit run -a` clean.
