### PR TITLE
add network switch to tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,11 @@ include = ["fusesoc", "fusesoc.capi2", "fusesoc.provider", "fusesoc.parser", "fu
 [project.scripts]
 fusesoc = "fusesoc.main:main"
 
+[tool.pytest.ini_options]
+markers = [
+    "network: test requires network access.",
+]
+
 [tool.tox]
 legacy_tox_ini = """
 [tox]

--- a/tests/test_coremanager.py
+++ b/tests/test_coremanager.py
@@ -174,6 +174,7 @@ def test_copyto():
     assert os.path.exists(os.path.join(work_root, "copytodot"))
 
 
+@pytest.mark.network
 def test_export():
     import os
     import tempfile

--- a/tests/test_libraries.py
+++ b/tests/test_libraries.py
@@ -9,6 +9,7 @@ import subprocess
 import tempfile
 from argparse import Namespace
 
+import pytest
 from test_common import cache_root, cores_root, library_root
 
 from fusesoc.config import Config
@@ -56,6 +57,7 @@ def test_library_location():
     fs.get_core("atlys")
 
 
+@pytest.mark.network
 def test_library_add(caplog):
     import tempfile
 
@@ -151,6 +153,7 @@ auto-sync = true"""
     tcf.close()
 
 
+@pytest.mark.network
 def test_library_update(caplog):
 
     clone_target = tempfile.mkdtemp()
@@ -210,6 +213,7 @@ def test_library_update(caplog):
     assert "test_lib : sync-type is local. Ignoring update" in caplog.text
 
 
+@pytest.mark.network
 def test_library_update_with_initialize(caplog):
     with tempfile.TemporaryDirectory() as library:
 

--- a/tests/test_provider.py
+++ b/tests/test_provider.py
@@ -15,6 +15,7 @@ from fusesoc.core import Core
 cores_root = os.path.join(tests_dir, "cores")
 
 
+@pytest.mark.network
 def test_git_provider():
     cache_root = tempfile.mkdtemp("git_")
     core = Core(
@@ -33,6 +34,7 @@ def test_git_provider():
         assert os.path.isfile(os.path.join(core.files_root, f))
 
 
+@pytest.mark.network
 def test_github_provider():
     cache_root = tempfile.mkdtemp("github_")
     core = Core(
@@ -87,6 +89,7 @@ def test_opencores_provider():
     assert os.path.isfile(os.path.join(core.files_root, "tap_top.v"))
 
 
+@pytest.mark.network
 def test_url_provider():
     cores_root = os.path.join(tests_dir, "capi2_cores", "providers")
 

--- a/tests/test_usecases.py
+++ b/tests/test_usecases.py
@@ -23,6 +23,7 @@ import pytest
 from fusesoc.main import main
 
 
+@pytest.mark.network
 def test_git_library_with_default_branch_is_added_and_updated(caplog):
     _fusesoc("library", "add", "https://github.com/fusesoc/fusesoc-generators")
     assert "Cloning library into fusesoc_libraries/fusesoc-generators" in caplog.text
@@ -32,6 +33,7 @@ def test_git_library_with_default_branch_is_added_and_updated(caplog):
     assert "Updating..." in caplog.text
 
 
+@pytest.mark.network
 def test_update_git_library_with_fixed_version(caplog, capsys):
     """
     Previously, one could not successfully use `fusesoc library update` on


### PR DESCRIPTION
This allows the user to filter out tests requiring network access.

```sh
pytest -m "not network"
```