### PR TITLE
Fix #751: include the full generator definition in the cache hash

### DIFF
--- a/fusesoc/edalizer.py
+++ b/fusesoc/edalizer.py
@@ -572,31 +572,19 @@ class Ttptttg:
         }
 
     def _sha256_input_yaml_hexdigest(self):
+        """Hash the generator inputs plus the generator definition itself.
+
+        The command, interpreter, and a hash of the script bytes are folded
+        in so editing the generator invalidates the cache. The resolved
+        interpreter path and the generator ``root`` are excluded to keep the
+        hash portable across machines and checkouts.
+        """
         data = self.generator_input.copy()
         # Remove files_root since that is not deterministic
         data.pop("files_root")
-        # Fold the generator definition into the hash so that updating the
-        # generator -- its declared command/interpreter *or* the script's
-        # bytes -- actually invalidates the cache. Without this a changed
-        # generator with unchanged user-facing inputs silently serves
-        # stale output. See #751.
-        #
-        # Deliberately NOT hashed:
-        #
-        # * The resolved interpreter path from ``shutil.which(interpreter)``
-        #   -- depends on the system PATH at run time and is not part of
-        #   the generator definition the user signs in their .core file.
-        # * The generator's ``root`` path -- it's an absolute path that
-        #   differs between machines/checkouts, which would make hashes
-        #   non-portable and cache directory names environment-specific.
-        #   Two generators with the same relative ``command`` rooted under
-        #   different directories are still distinguished here by
-        #   ``__generator_script_hash__``: if their script bytes differ,
-        #   the hash differs; if their bytes match, sharing the cache is
-        #   the desired behaviour.
-        data["__generator_command__"] = self.generator.get("command", "")
-        data["__generator_interpreter__"] = self.generator.get("interpreter", "")
-        data["__generator_script_hash__"] = self._generator_script_sha256()
+        data["generator_command"] = self.generator.get("command", "")
+        data["generator_interpreter"] = self.generator.get("interpreter", "")
+        data["generator_script_hash"] = self._generator_script_sha256()
         return hashlib.sha256(utils.yaml_dump(data).encode()).hexdigest()
 
     def _generator_script_sha256(self):

--- a/fusesoc/edalizer.py
+++ b/fusesoc/edalizer.py
@@ -575,7 +575,50 @@ class Ttptttg:
         data = self.generator_input.copy()
         # Remove files_root since that is not deterministic
         data.pop("files_root")
+        # Fold the generator definition into the hash so that updating the
+        # generator -- its declared command/interpreter *or* the script's
+        # bytes -- actually invalidates the cache. Without this a changed
+        # generator with unchanged user-facing inputs silently serves
+        # stale output. See #751.
+        #
+        # Deliberately NOT hashed:
+        #
+        # * The resolved interpreter path from ``shutil.which(interpreter)``
+        #   -- depends on the system PATH at run time and is not part of
+        #   the generator definition the user signs in their .core file.
+        # * The generator's ``root`` path -- it's an absolute path that
+        #   differs between machines/checkouts, which would make hashes
+        #   non-portable and cache directory names environment-specific.
+        #   Two generators with the same relative ``command`` rooted under
+        #   different directories are still distinguished here by
+        #   ``__generator_script_hash__``: if their script bytes differ,
+        #   the hash differs; if their bytes match, sharing the cache is
+        #   the desired behaviour.
+        data["__generator_command__"] = self.generator.get("command", "")
+        data["__generator_interpreter__"] = self.generator.get("interpreter", "")
+        data["__generator_script_hash__"] = self._generator_script_sha256()
         return hashlib.sha256(utils.yaml_dump(data).encode()).hexdigest()
+
+    def _generator_script_sha256(self):
+        """SHA-256 of the resolved generator script bytes, or ``None`` if
+        the script cannot be read.
+
+        The ``None`` sentinel is intentional: a script that is unreadable
+        on one run and readable on the next still flips the marker, which
+        is the conservative direction. Likewise, an in-place edit of the
+        script flips the hash even though the path on disk is unchanged
+        -- this is the gap that the literal command/interpreter strings
+        alone cannot close.
+        """
+        root = self.generator.get("root")
+        command = self.generator.get("command")
+        if not root or not command:
+            return None
+        script_path = os.path.join(os.path.abspath(root), command)
+        try:
+            return hashlib.sha256(pathlib.Path(script_path).read_bytes()).hexdigest()
+        except OSError:
+            return None
 
     def _sha256_file_input_hexdigest(self):
         input_files = []

--- a/tests/test_edalizer.py
+++ b/tests/test_edalizer.py
@@ -282,7 +282,7 @@ def test_generators():
     assert core_root.is_dir()
     assert (
         core_root.name
-        == "generate-testgenerate_with_cache_0-3ecde28208c91a7f077b518fcec91f115affa02a34204790f654f6ba13efe2bd"
+        == "generate-testgenerate_with_cache_0-dd0cbabeb8396cc34c551cb738a9d4cbf1fb6ba0fafca24be5aa55c03839a40f"
     )
     shutil.rmtree(core.core_root, ignore_errors=True)
 
@@ -299,7 +299,7 @@ def test_generators():
     )
     assert (
         core_root.parent.name
-        == "generate-testgenerate_with_file_cache_0-01cdfe6a25d93d4dacd9c477db1e75feb62cec19d935cae0b3130d6ffebeab62"
+        == "generate-testgenerate_with_file_cache_0-71f6f955798bff1e5f67c76f40f9715d5fc12e6ccbb8919fc607f9c222db7452"
     )
     shutil.rmtree(core.core_root, ignore_errors=True)
 
@@ -340,11 +340,9 @@ def test_hook_script_names_are_unique_per_core():
     assert "hookcollision-child_0_myhook" in names
 
 
-def test_generator_input_hash_includes_command(tmp_path):
-    """``Ttptttg._sha256_input_yaml_hexdigest`` must fold the generator's
-    ``command`` (and ``interpreter``) into the cache hash. Without that,
-    a user updating the generator script (same parameters, same input
-    files) silently keeps getting the previously-cached output.
+def test_changing_generator_command_invalidates_cache_hash(tmp_path):
+    """Changing the generator's ``command`` produces a different cache hash,
+    so an updated generator does not reuse a previous run's cached output.
 
     Regression test for https://github.com/olofk/fusesoc/issues/751.
     """
@@ -384,13 +382,13 @@ def test_generator_input_hash_includes_command(tmp_path):
     h_new = hash_with_cmd("gen_v2.py")
     h_repeat = hash_with_cmd("gen_v1.py")
 
-    assert h_old != h_new, "changing generator command must invalidate the cache hash"
-    assert h_old == h_repeat, "same command must produce stable hash"
+    assert h_old != h_new, "changing generator command changes the cache hash"
+    assert h_old == h_repeat, "same command produces a stable hash"
 
 
-def test_generator_input_hash_includes_interpreter(tmp_path):
-    """Swapping the interpreter (e.g. ``python3`` → ``python2``) is also a
-    real environment change that should invalidate the cache."""
+def test_changing_generator_interpreter_invalidates_cache_hash(tmp_path):
+    """Swapping the interpreter (e.g. ``python3`` → ``python2``)
+    invalidates the cache."""
     from types import SimpleNamespace
 
     from fusesoc.edalizer import Ttptttg
@@ -423,12 +421,10 @@ def test_generator_input_hash_includes_interpreter(tmp_path):
     assert hash_with_interp("python3") != hash_with_interp("python2")
 
 
-def test_generator_input_hash_includes_script_bytes(tmp_path):
+def test_editing_generator_script_invalidates_cache_hash(tmp_path):
     """Editing the generator script in place -- same path, same
-    declarations -- must still invalidate the cache. The literal
-    ``command`` / ``interpreter`` strings alone don't catch this; the
-    fix folds a SHA-256 of the resolved script bytes into the hash.
-    Regression for the gap codex flagged on top of issue #751.
+    declarations -- changes the cache hash, because the hash folds in a
+    SHA-256 of the resolved script bytes.
     """
     from types import SimpleNamespace
 

--- a/tests/test_edalizer.py
+++ b/tests/test_edalizer.py
@@ -282,7 +282,7 @@ def test_generators():
     assert core_root.is_dir()
     assert (
         core_root.name
-        == "generate-testgenerate_with_cache_0-616d6cf151dba72fcd893c08a8e18e6dba2b81ee25dec08c92e0177064dfc18c"
+        == "generate-testgenerate_with_cache_0-3ecde28208c91a7f077b518fcec91f115affa02a34204790f654f6ba13efe2bd"
     )
     shutil.rmtree(core.core_root, ignore_errors=True)
 
@@ -299,7 +299,7 @@ def test_generators():
     )
     assert (
         core_root.parent.name
-        == "generate-testgenerate_with_file_cache_0-f3d9e1e462ef1f7113fafbacd62d6335dd684e69332f75498fb01bfaaa7c11ee"
+        == "generate-testgenerate_with_file_cache_0-01cdfe6a25d93d4dacd9c477db1e75feb62cec19d935cae0b3130d6ffebeab62"
     )
     shutil.rmtree(core.core_root, ignore_errors=True)
 
@@ -338,3 +338,146 @@ def test_hook_script_names_are_unique_per_core():
     assert len(set(names)) == 2, f"hook script names collided: {names}"
     assert "hookcollision-parent_0_myhook" in names
     assert "hookcollision-child_0_myhook" in names
+
+
+def test_generator_input_hash_includes_command(tmp_path):
+    """``Ttptttg._sha256_input_yaml_hexdigest`` must fold the generator's
+    ``command`` (and ``interpreter``) into the cache hash. Without that,
+    a user updating the generator script (same parameters, same input
+    files) silently keeps getting the previously-cached output.
+
+    Regression test for https://github.com/olofk/fusesoc/issues/751.
+    """
+    from types import SimpleNamespace
+
+    from fusesoc.edalizer import Ttptttg
+    from fusesoc.vlnv import Vlnv
+
+    # Minimal core stand-in: Ttptttg only touches .name, .cache_root,
+    # .files_root.
+    fake_core = SimpleNamespace(
+        name=Vlnv("::fake:0.1.0"),
+        cache_root=str(tmp_path / "cache"),
+        files_root=str(tmp_path / "src"),
+    )
+
+    ttptttg = {
+        "generator": "mygen",
+        "name": "inst",
+        "pos": "append",
+        "config": {"foo": "bar"},
+    }
+
+    def hash_with_cmd(cmd):
+        generators = {
+            "mygen": {
+                "command": cmd,
+                "interpreter": "python3",
+                "root": str(tmp_path),
+                "cache_type": "input",
+            }
+        }
+        t = Ttptttg(ttptttg, fake_core, generators, str(tmp_path / "work"))
+        return t._sha256_input_yaml_hexdigest()
+
+    h_old = hash_with_cmd("gen_v1.py")
+    h_new = hash_with_cmd("gen_v2.py")
+    h_repeat = hash_with_cmd("gen_v1.py")
+
+    assert h_old != h_new, "changing generator command must invalidate the cache hash"
+    assert h_old == h_repeat, "same command must produce stable hash"
+
+
+def test_generator_input_hash_includes_interpreter(tmp_path):
+    """Swapping the interpreter (e.g. ``python3`` → ``python2``) is also a
+    real environment change that should invalidate the cache."""
+    from types import SimpleNamespace
+
+    from fusesoc.edalizer import Ttptttg
+    from fusesoc.vlnv import Vlnv
+
+    fake_core = SimpleNamespace(
+        name=Vlnv("::fake:0.1.0"),
+        cache_root=str(tmp_path / "cache"),
+        files_root=str(tmp_path / "src"),
+    )
+    ttptttg = {
+        "generator": "mygen",
+        "name": "inst",
+        "pos": "append",
+        "config": {},
+    }
+
+    def hash_with_interp(interp):
+        generators = {
+            "mygen": {
+                "command": "gen.py",
+                "interpreter": interp,
+                "root": str(tmp_path),
+                "cache_type": "input",
+            }
+        }
+        t = Ttptttg(ttptttg, fake_core, generators, str(tmp_path / "work"))
+        return t._sha256_input_yaml_hexdigest()
+
+    assert hash_with_interp("python3") != hash_with_interp("python2")
+
+
+def test_generator_input_hash_includes_script_bytes(tmp_path):
+    """Editing the generator script in place -- same path, same
+    declarations -- must still invalidate the cache. The literal
+    ``command`` / ``interpreter`` strings alone don't catch this; the
+    fix folds a SHA-256 of the resolved script bytes into the hash.
+    Regression for the gap codex flagged on top of issue #751.
+    """
+    from types import SimpleNamespace
+
+    from fusesoc.edalizer import Ttptttg
+    from fusesoc.vlnv import Vlnv
+
+    gen_root = tmp_path / "gen"
+    gen_root.mkdir()
+    script = gen_root / "gen.py"
+
+    fake_core = SimpleNamespace(
+        name=Vlnv("::fake:0.1.0"),
+        cache_root=str(tmp_path / "cache"),
+        files_root=str(tmp_path / "src"),
+    )
+    ttptttg = {
+        "generator": "mygen",
+        "name": "inst",
+        "pos": "append",
+        "config": {},
+    }
+    generators = {
+        "mygen": {
+            "command": "gen.py",
+            "interpreter": "python3",
+            "root": str(gen_root),
+            "cache_type": "input",
+        }
+    }
+
+    def current_hash():
+        t = Ttptttg(ttptttg, fake_core, generators, str(tmp_path / "work"))
+        return t._sha256_input_yaml_hexdigest()
+
+    # 1. Script missing -- hash is well-defined (None sentinel).
+    h_missing = current_hash()
+
+    # 2. Script created with v1 bytes -- hash flips.
+    script.write_text("# generator v1\nprint('hello v1')\n")
+    h_v1 = current_hash()
+    assert h_v1 != h_missing
+
+    # 3. Script edited in place to v2 -- hash flips again.
+    script.write_text("# generator v2\nprint('hello v2')\n")
+    h_v2 = current_hash()
+    assert h_v2 != h_v1
+
+    # 4. Reverting to v1 bytes -- hash returns to the v1 value
+    # (proves the hash depends on bytes, not on "has the file been
+    # touched"-style ctime/mtime heuristics).
+    script.write_text("# generator v1\nprint('hello v1')\n")
+    assert current_hash() == h_v1


### PR DESCRIPTION
## Problem
Fixes https://github.com/olofk/fusesoc/issues/751.

`Ttptttg._sha256_input_yaml_hexdigest` hashes only `{parameters, vlnv, gapi}` from `generator_input`. Editing the generator — whether by pointing `command:`/`interpreter:` at a different file or by editing the script's bytes in place — leaves the hash identical, so subsequent runs silently serve the previously-cached output even though the program that produced it has changed.

## Solution
Fold the generator definition into the hash: `command`, `interpreter`, and a SHA-256 of the resolved script bytes. A clean rebuild now happens whenever any of these changes.

Why slightly broader than the literal ask in the issue: "the command being executed" naturally includes the script content, not just the declared path. Hashing only the declared `command:` string catches renames but not in-place script edits — which is the common "I updated the generator and the cache still served stale output" symptom. Hashing the resolved bytes closes that gap and mirrors the pattern PR #777 uses for provider patch bytes.

**Deliberately NOT hashed:**
- The resolved interpreter path from `shutil.which(interpreter)`. That depends on the system PATH at run time and is not part of the generator definition the user signs in their `.core` file. The interpreter name is what we sign.
- The generator's `root` path. It's an absolute path that differs between machines and checkouts, which would make cache directory names environment-specific and the test reference hashes machine-specific. Two generators with the same relative `command` rooted under different directories are still distinguished by the script bytes hash: if their bytes differ, the cache differs; if their bytes match, sharing the cache is the desired behaviour.

This necessarily invalidates existing on-disk caches for cacheable generators on first run after upgrade (the directory name embeds the hash). Users get one extra regeneration and consistent behaviour afterwards. The hardcoded reference hashes in `test_generators` are updated accordingly.

## Test plan
- [x] `test_generator_input_hash_includes_command` — proves changing `command` flips the hash; stable across repeats.
- [x] `test_generator_input_hash_includes_interpreter` — proves swapping `python3` → `python2` flips the hash.
- [x] `test_generator_input_hash_includes_script_bytes` — missing → v1 → v2 → v1-again sequence, proving the hash depends on bytes not on mtime.
- [x] Existing `test_generators` reference hashes updated; full `tests/test_edalizer.py` green (7 passed).
- [x] `pre-commit run -a` clean.
