### PR TITLE
Fix pyparsing version constraint to guarantee new API method names exist

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ dynamic = ["version"]
 
 dependencies = [
   "edalize>=0.4.1",
-  "pyparsing>=2.3.1",
+  "pyparsing>=3.0.0",
   "pyyaml>=6.0",
   "pydantic>=2.13.3",
   "simplesat>=0.9.1",


### PR DESCRIPTION
Fixes SERV CI failure: https://github.com/olofk/serv/actions/runs/27573214260/job/81514769565