### PR TITLE
feat: add list type when passing options from command line to Edalize flow backend

### DIFF
--- a/fusesoc/edalizer.py
+++ b/fusesoc/edalizer.py
@@ -7,6 +7,7 @@ import hashlib
 import logging
 import os
 import pathlib
+import shlex
 import shutil
 from filecmp import cmp
 from importlib import import_module
@@ -23,10 +24,10 @@ logger = logging.getLogger(__name__)
 
 class FileAction(argparse.Action):
     def __call__(self, parser, namespace, values, option_string=None):
-        path = os.path.expandvars(values[0])
+        path = os.path.expandvars(values)
         path = os.path.expanduser(path)
         path = os.path.abspath(path)
-        setattr(namespace, self.dest, [path])
+        setattr(namespace, self.dest, path)
 
 
 def str2bool(v):
@@ -38,6 +39,22 @@ def str2bool(v):
         return False
     else:
         raise argparse.ArgumentTypeError("Boolean value expected.")
+
+
+#: Conversion table between Edalize types and FuseSoC command line arguments
+#: The ``metavar`` is used to inform users about expected value type
+_TYPEDICT_PARAMETERS = {
+    "bool": {"type": str2bool, "nargs": "?", "const": True, "metavar": "yes|no"},
+    "file": {"type": str, "action": FileAction, "metavar": "FILE"},
+    "int": {"type": int, "metavar": "INTEGER"},
+    "str": {"type": str, "metavar": "ARG"},
+    "real": {"type": float, "metavar": "NUMBER"},
+}
+
+_TYPEDICT_OPTIONS = {
+    **_TYPEDICT_PARAMETERS,
+    "list": {"type": shlex.split, "metavar": "ARGS"},
+}
 
 
 class Edalizer:
@@ -332,13 +349,6 @@ class Edalizer:
             merge_dict(self.edam, snippet)
 
     def _build_parser(self, backend_class, edam):
-        typedict = {
-            "bool": {"type": str2bool, "nargs": "?", "const": True},
-            "file": {"type": str, "nargs": 1, "action": FileAction},
-            "int": {"type": int, "nargs": 1},
-            "str": {"type": str, "nargs": 1},
-            "real": {"type": float, "nargs": 1},
-        }
         progname = "fusesoc run {}".format(edam["name"])
 
         parser = argparse.ArgumentParser(prog=progname, conflict_handler="resolve")
@@ -362,15 +372,12 @@ class Edalizer:
                         _descr[_paramtype]
                     )
 
-                default = None
-                if param.get("default") is not None:
+                default = param.get("default")
+                if default is not None:
                     try:
-                        if param["datatype"] == "bool":
-                            default = param["default"]
-                        else:
-                            default = [
-                                typedict[param["datatype"]]["type"](param["default"])
-                            ]
+                        default = _TYPEDICT_PARAMETERS[param["datatype"]]["type"](
+                            default
+                        )
                     except KeyError:
                         pass
                 try:
@@ -378,7 +385,7 @@ class Edalizer:
                         "--" + name,
                         help=_description,
                         default=default,
-                        **typedict[param["datatype"]],
+                        **_TYPEDICT_PARAMETERS[param["datatype"]],
                     )
                 except KeyError as e:
                     raise RuntimeError(
@@ -400,7 +407,7 @@ class Edalizer:
                 backend_args.add_argument(
                     "--" + k,
                     help=v["desc"],
-                    **typedict[v["type"]],
+                    **_TYPEDICT_OPTIONS[v["type"]],
                 )
             for k, v in backend_class.get_tool_options(
                 self.activated_flow_options
@@ -408,7 +415,7 @@ class Edalizer:
                 backend_args.add_argument(
                     "--" + k,
                     help=v["desc"],
-                    **typedict[v["type"]],
+                    **_TYPEDICT_OPTIONS[v["type"]],
                 )
         else:
             _opts = backend_class.get_doc(0)
@@ -475,18 +482,11 @@ class Edalizer:
             prog=progname, conflict_handler="resolve", add_help=False
         )
         backend_args = parser.add_argument_group("Flow options")
-        typedict = {
-            "bool": {"type": str2bool, "nargs": "?", "const": True},
-            "file": {"type": str, "nargs": 1, "action": FileAction},
-            "int": {"type": int, "nargs": 1},
-            "str": {"type": str, "nargs": 1},
-            "real": {"type": float, "nargs": 1},
-        }
         for k, v in available_flow_options.items():
             backend_args.add_argument(
                 "--" + k,
                 help=v["desc"],
-                **typedict[v["type"]],
+                **_TYPEDICT_OPTIONS[v["type"]],
             )
 
         # Parse known args (i.e. only flow options) from the command-line
@@ -499,12 +499,8 @@ class Edalizer:
             # on the command line
             if value is None:
                 continue
-            _value = value[0] if isinstance(value, list) else value
 
-            # If flow option is a list, we split up the parsed string
-            if "list" in available_flow_options[key]:
-                _value = _value.split(" ")
-            parsed_args_dict[key] = _value
+            parsed_args_dict[key] = value
 
         # Add parsed args to the ones from the EDAM
         merge_dict(flow_options, parsed_args_dict)
@@ -527,8 +523,7 @@ class Edalizer:
         for key, value in sorted(vars(parsed_args).items()):
             if value is None:
                 continue
-            _value = value[0] if isinstance(value, list) else value
-            args_dict[key] = _value
+            args_dict[key] = value
 
         self.add_parsed_args(backend_class, args_dict)
 

--- a/tests/test_edalizer.py
+++ b/tests/test_edalizer.py
@@ -2,10 +2,13 @@
 # Licensed under the 2-Clause BSD License, see LICENSE for details.
 # SPDX-License-Identifier: BSD-2-Clause
 
+import shlex
+from pathlib import Path
+
+import pytest
+
 
 def test_apply_filters(caplog):
-    import pytest
-
     from fusesoc.edalizer import Edalizer
 
     input_edam = {
@@ -338,3 +341,221 @@ def test_hook_script_names_are_unique_per_core():
     assert len(set(names)) == 2, f"hook script names collided: {names}"
     assert "hookcollision-parent_0_myhook" in names
     assert "hookcollision-child_0_myhook" in names
+
+
+@pytest.mark.parametrize(
+    "datatype,value",
+    (
+        ("bool", None),
+        ("bool", "FalSE"),
+        ("bool", "f"),
+        ("bool", "No"),
+        ("bool", "n"),
+        ("bool", "0"),
+        ("bool", "tRuE"),
+        ("bool", "t"),
+        ("bool", "Yes"),
+        ("bool", "y"),
+        ("bool", "1"),
+        ("int", None),
+        ("int", -2137),
+        ("int", 0),
+        ("int", 2137),
+        ("real", None),
+        ("real", -0.25),
+        ("real", 0.0),
+        ("real", 0.25),
+        ("str", None),
+        ("str", ""),
+        ("str", "arg"),
+        ("str", "arg with spaces"),
+        ("list", None),
+        ("list", ""),
+        ("list", "-arg1"),
+        ("list", "-arg1 val1"),
+        ("list", "-arg1 val1 -arg2"),
+        ("list", "-arg1 val1 -arg2 val2"),
+        ("list", "-arg1 val1 -arg2 'val2 with single quote'"),
+        ("list", '-arg1 val1 -arg2 "val2 with double quote"'),
+        ("file", None),
+        ("file", "input.tcl"),
+    ),
+)
+def test_edalizer_parse_args_for_options(datatype: str, value: object) -> None:
+    """Test parsing arguments for options by the Edalizer class."""
+    from edalize.flows.edaflow import Edaflow
+
+    from fusesoc.edalizer import Edalizer
+
+    name = f"my_{datatype}_option"
+
+    class MyFlow(Edaflow):
+        argtypes = []
+
+        FLOW_OPTIONS = {
+            name: {"type": datatype, "desc": "Description"},
+        }
+
+    edalizer = Edalizer(
+        toplevel=None,
+        flags=None,
+        work_root=None,
+        core_manager=None,
+    )
+
+    edalizer.edam = {
+        "name": "flow",
+        "flow_options": {},
+        "parameters": {},
+    }
+
+    backendargs: list[str]
+
+    if value is None:
+        backendargs = [f"--{name}"] if datatype == "bool" else []
+    elif datatype == "list":
+        # To pass arguments with leading dashes to backend
+        backendargs = [f"--{name}={value}"]
+    else:
+        backendargs = [f"--{name}", str(value)]
+
+    edalizer.parse_args(MyFlow, backendargs)
+
+    expected: object = None
+
+    # Convert provided command line value to expected type for the Edalize
+    if value is None and datatype != "bool":
+        pass
+    elif datatype == "bool":
+        if value is None or str(value).lower() in ("yes", "true", "t", "y", "1"):
+            expected = True
+        else:
+            expected = False
+    elif datatype == "int":
+        expected = int(value)
+    elif datatype == "real":
+        expected = float(value)
+    elif datatype == "str":
+        expected = str(value)
+    elif datatype == "list":
+        expected = shlex.split(str(value))
+    elif datatype == "file":
+        expected = str(Path(value).resolve())
+
+    assert edalizer.edam["parameters"] == {}
+
+    if expected is None and datatype != "bool":
+        # Option was defined but not used
+        assert edalizer.activated_flow_options == {}
+        assert name not in edalizer.edam["flow_options"]
+    else:
+        # Option was defined and used
+        assert edalizer.activated_flow_options == {name: expected}
+        assert edalizer.edam["flow_options"][name] == expected
+
+
+@pytest.mark.parametrize(
+    "datatype,value,default",
+    (
+        ("bool", None, None),
+        ("bool", "FalSE", True),
+        ("bool", "f", True),
+        ("bool", "No", True),
+        ("bool", "n", True),
+        ("bool", "0", True),
+        ("bool", "tRuE", False),
+        ("bool", "t", False),
+        ("bool", "Yes", False),
+        ("bool", "y", False),
+        ("bool", "1", False),
+        ("int", None, None),
+        ("int", -2137, 10),
+        ("int", 0, 2137),
+        ("int", 2137, -10),
+        ("real", None, None),
+        ("real", -0.25, 5),
+        ("real", 0.0, 5.0),
+        ("real", 0.25, -5),
+        ("str", None, None),
+        ("str", "", "default"),
+        ("str", "arg", "default"),
+        ("str", "arg with spaces", "default"),
+        ("file", None, None),
+        ("file", "input.tcl", "default.tcl"),
+    ),
+)
+@pytest.mark.parametrize(
+    "paramtype",
+    (
+        "plusarg",
+        "vlogparam",
+        "vlogdefine",
+        "generic",
+        "cmdlinearg",
+    ),
+)
+def test_edalizer_parse_args_for_parameters(
+    datatype: str, value: object, default: object, paramtype: str
+) -> None:
+    """Test parsing arguments for parameters by the Edalizer class."""
+    from edalize.flows.edaflow import Edaflow
+
+    from fusesoc.edalizer import Edalizer
+
+    name = f"my_{datatype}_parameter"
+
+    class MyFlow(Edaflow):
+        argtypes = [paramtype]
+
+        FLOW_OPTIONS = {}
+
+    edalizer = Edalizer(
+        toplevel=None,
+        flags=None,
+        work_root=None,
+        core_manager=None,
+    )
+
+    edalizer.edam = {
+        "name": "flow",
+        "flow_options": {},
+        "parameters": {
+            name: {
+                "datatype": datatype,
+                "paramtype": paramtype,
+                "default": default,
+            },
+        },
+    }
+
+    backendargs: list[str]
+
+    if value is None:
+        backendargs = [f"--{name}"] if datatype == "bool" else []
+    else:
+        backendargs = [f"--{name}", str(value)]
+
+    edalizer.parse_args(MyFlow, backendargs)
+
+    expected: object = None
+
+    # Convert provided command line value to expected type for the Edalize
+    if value is None and datatype != "bool":
+        pass
+    elif datatype == "bool":
+        if value is None or str(value).lower() in ("yes", "true", "t", "y", "1"):
+            expected = True
+        else:
+            expected = False
+    elif datatype == "int":
+        expected = int(value)
+    elif datatype == "real":
+        expected = float(value)
+    elif datatype == "str":
+        expected = str(value)
+    elif datatype == "file":
+        expected = str(Path(value).resolve())
+
+    assert edalizer.activated_flow_options == {}
+    assert edalizer.edam["flow_options"] == {}
+    assert edalizer.edam["parameters"][name]["default"] == expected


### PR DESCRIPTION
Closes https://github.com/olofk/fusesoc/issues/790

Context: https://github.com/olofk/edalize/pull/537#issuecomment-4842115269

This PR is needed to pass tool arguments directly from `fusesoc` command line interface to Edalize backend flow. Example:

```plaintext
fusesoc run --target sim <core> --xrun_options="-input script.tcl -access +rwc"
```

This was not supported because `fusesoc` wasn't able to handle a list of arguments. Supported types were limited to `bool`, `str`, `int`, `real` or `file`.

This PR:

* Added a new type `list` to handle arguments (including dashes, quotes and whitespace characters) that will be passed to Edalize backend
* Removed unnecessary `nargs=1`. They should not be used when passing a single value because it is hard to distinguish a non-list value from a list. Additionally, this also removes unnecessary brackets `[]` around metavars when invoking the help
* Added `metavar` to inform users about expected value type. By default, the Python ArgumentParser is using upper-case name of option. It only duplicates a name without providing any value in return for end users
* Replaced duplicated `dictype` with the global `_DICTTYPE` 

Added an unit test to test all variants:

```plaintext
pytest -k 'test_edalizer_parse_args'
```

All files were linted with the pre-commit.