### PR TITLE
Fix "fusesoc tool list" with edalize 0.6.2+

### DIFF
--- a/fusesoc/main.py
+++ b/fusesoc/main.py
@@ -36,7 +36,7 @@ def _get_core(cm, core_name):
     matches = set()
     if ":" not in core_name:
         for core in cm.get_cores():
-            (vendor, library, name, _) = core.split(":")
+            vendor, library, name, _ = core.split(":")
             if name.lower() == core_name.lower():
                 matches.add(f"{vendor}:{library}:{name}")
         if len(matches) == 1:
@@ -217,10 +217,12 @@ def list_cores(fs, args):
 
 def list_tools(fs, args):
     import edalize.edatool
+
     if hasattr(edalize.edatool, "get_edatool_map"):
         # edalize>=0.6.2
         from edalize.edatool import get_edatool_map
-        NON_TOOLS = ["edatool"] # edalize reports this abstract class as a tool
+
+        NON_TOOLS = ["edatool"]  # edalize reports this abstract class as a tool
         tools = get_edatool_map()
         maxlen = max(map(len, tools.keys()))
 
@@ -248,7 +250,6 @@ def list_tools(fs, args):
             # Ignore any misbehaving backends
             except Exception:
                 pass
-
 
 
 def gen_list(fs, args):
@@ -541,17 +542,17 @@ def get_parser():
     parser_core_show = core_subparsers.add_parser(
         "show", help="Show information about a core"
     )
-    parser_core_show.add_argument(
-        "core", help="Name of the core to show"
-    ).completer = CoreCompleter()
+    parser_core_show.add_argument("core", help="Name of the core to show").completer = (
+        CoreCompleter()
+    )
     parser_core_show.set_defaults(func=core_info)
 
     parser_core_sign = core_subparsers.add_parser(
         "sign", help="Create user signature for a core"
     )
-    parser_core_sign.add_argument(
-        "core", help="Name of the core to sign"
-    ).completer = CoreCompleter()
+    parser_core_sign.add_argument("core", help="Name of the core to sign").completer = (
+        CoreCompleter()
+    )
     parser_core_sign.add_argument("keyfile", help="File containing ssh private key")
     parser_core_sign.set_defaults(func=core_sign)
 

--- a/fusesoc/main.py
+++ b/fusesoc/main.py
@@ -216,19 +216,39 @@ def list_cores(fs, args):
 
 
 def list_tools(fs, args):
-    from edalize.edatool import get_edatool, walk_tool_packages
+    import edalize.edatool
+    if hasattr(edalize.edatool, "get_edatool_map"):
+        # edalize>=0.6.2
+        from edalize.edatool import get_edatool_map
+        NON_TOOLS = ["edatool"] # edalize reports this abstract class as a tool
+        tools = get_edatool_map()
+        maxlen = max(map(len, tools.keys()))
 
-    _tp = list(walk_tool_packages())
-    maxlen = max(map(len, _tp))
+        for name, tool in tools.items():
+            if name in NON_TOOLS:
+                continue
+            try:
+                desc = tool.tool_class.get_doc(0)["description"]
+                print(f"{name:{maxlen}}: {desc}")
+            # Ignore any misbehaving backends
+            except Exception:
+                pass
+    else:
+        # edalize<=0.6.1
+        from edalize.edatool import get_edatool, walk_tool_packages
 
-    for tool_name in _tp:
-        try:
-            tool_class = get_edatool(tool_name)
-            desc = tool_class.get_doc(0)["description"]
-            print(f"{tool_name:{maxlen}} : {desc}")
-        # Ignore any misbehaving backends
-        except Exception:
-            pass
+        _tp = list(walk_tool_packages())
+        maxlen = max(map(len, _tp))
+
+        for tool_name in _tp:
+            try:
+                tool_class = get_edatool(tool_name)
+                desc = tool_class.get_doc(0)["description"]
+                print(f"{tool_name:{maxlen}} : {desc}")
+            # Ignore any misbehaving backends
+            except Exception:
+                pass
+
 
 
 def gen_list(fs, args):


### PR DESCRIPTION
PR #769 seems to have been abandoned. This adds the requested `black` formatting to the original patch so the fix can be merged.

Fixes #755 

