### PR TITLE
Support default "tool" and "flow" flags when using flow API

### DIFF
--- a/doc/source/user/build_system/flags.rst
+++ b/doc/source/user/build_system/flags.rst
@@ -33,6 +33,9 @@ When running ``fusesoc run`` some flags are automatically made available.
 * ``target_TARGETNAME``: A flag that is set if a particular target is being built.
   ``TARGETNAME`` is replaced with the name of the target that is being built.
   For example, if the target ``synth`` is being built, the flag ``target_synth`` will be set.
+* ``flow_FLOWNAME``: A flag that is set when a particular flow is being run.
+  ``FLOWNAME`` is replaced with the name of the flow that is being run.
+  For example, if the simulation flow is being run, the flag ``flow_sim`` will be set.
 
 User-defined flags
 ~~~~~~~~~~~~~~~~~~

--- a/fusesoc/main.py
+++ b/fusesoc/main.py
@@ -373,6 +373,23 @@ def run(fs, args):
         logger.error(str(e))
         exit(1)
 
+    try:
+        flow = core.get_flow(flags)
+        if flow and "flow" not in flags:
+            flags["flow"] = flow
+
+            flow_options = core.get_flow_options(
+                {"is_toplevel": True, **flags}
+            )
+            if flow_options and "tool" in flow_options and "tool" not in flags:
+                flags["tool"] = flow_options["tool"]
+    except SyntaxError as e:
+        logger.error(str(e))
+        exit(1)
+    except RuntimeError as e:
+        logger.error(str(e))
+        exit(1)
+
     # Unconditionally clean out the work root on fresh builds
     # if we use the old tool API or clean flag is set
     if do_configure and (not core.get_flow(flags) or args.clean):


### PR DESCRIPTION
Fixes an issue where the default `tool_TOOLNAME` flags were never being set if not using the tool API. Also adds a default `flow_FLOWNAME` flag.

Passes ruff and tox (no new unit tests added).