### PR TITLE
feat(yaml): relaxing the requirement for the CAPI=2: directive that must be in the first line

### DIFF
--- a/doc/source/user/build_system/core_files.rst
+++ b/doc/source/user/build_system/core_files.rst
@@ -108,12 +108,30 @@ Naming the core file
 The core file can have any name, but it must end in ``.core``.
 It is recommended to choose a file name matching the core name, as discussed below.
 
-The first line: ``CAPI=2``
---------------------------
+The ``CAPI=2:`` directive at the beginning of the core file
+-----------------------------------------------------------
 
-A core file always starts with the line ``CAPI=2``.
-No other content (including comments) is allowed before this line, as FuseSoC uses this line to differentiate between different versions of the CAPI schema.
+A core file **MUST** always have the ``CAPI=2:`` directive at the beginning of the document.
+FuseSoC uses this directive to differentiate between different versions of the CAPI schema.
 Only CAPI version 2 is specified at the moment.
+
+Allowed content before the ``CAPI=2:`` directive:
+
+* `YAML directives`_ like ``%YAML 1.2`` or ``%TAG``
+* `YAML start document indicator`_ ``---```
+* Comments starting by the ``#`` hash character
+* Empty lines
+
+For example:
+
+.. code:: yaml
+
+    %YAML 1.2
+    ---
+    # SPDX-FileCopyrightText: © 2026 John Doe <john.doe@fusesoc.com>
+    # SPDX-License-Identifier: BSD-2-Clause
+
+    CAPI=2:
 
 .. _ug_build_system_core_name:
 
@@ -296,3 +314,6 @@ This setting can also be overridden using the command line option ``--ssh-trustf
 The signing process is accomplished with the ``core sign`` command, which takes a core name and a path to a private ssh key as arguments.
 
 The signing status of a core is shown in the ``core list`` and ``core show`` commands in the fusesoc cli tool.
+
+.. _YAML directives: https://yaml.org/spec/1.2.2/#directives
+.. _YAML start document indicator: https://yaml.org/spec/1.2.2/#22-structures

--- a/fusesoc/capi2/json_schema.py
+++ b/fusesoc/capi2/json_schema.py
@@ -5,6 +5,10 @@ capi2_schema = """
   "description": "Core API Version 2",
   "type": "object",
   "properties": {
+    "CAPI=2": {
+      "description": "Short for 'Core API version 2'. The schema or 'language' used in core files.",
+      "type": "null",
+    },
     "description": {
       "description": "Short description of core",
       "type": "string"

--- a/fusesoc/coremanager.py
+++ b/fusesoc/coremanager.py
@@ -507,34 +507,31 @@ class CoreManager:
         """
         try:
             with open(core_file) as f:
-                lines = f.readline().split()
-                if lines:
-                    first_line = lines[0]
-                else:
-                    first_line = ""
-                if first_line == "CAPI=1":
-                    return 1
-                elif first_line == "CAPI=2:":
-                    return 2
-                else:
-                    error_msg = (
-                        "The first line of the core file {} must be "
-                        ' "CAPI=1" or "CAPI=2:".'.format(core_file)
-                    )
-                    error_msg += '  The first line of this core file is "{}".'.format(
-                        first_line
-                    )
-                    if first_line == "CAPI=2":
-                        error_msg += "  Just add a colon on the end!"
-                    logger.warning(error_msg)
-                    raise ValueError(
-                        "Unable to determine CAPI version from core file {}.".format(
-                            core_file
+                while line := f.readline():
+                    line = line.strip()
+
+                    if not line or line == "---" or line[0] in ("%", "#"):
+                        # Allow YAML start document indicator ---, YAML directive %, empty lines and comments
+                        continue
+
+                    if line == "CAPI=1":
+                        return 1
+
+                    if line == "CAPI=2:":
+                        return 2
+
+                    if line == "CAPI=2":
+                        raise ValueError(
+                            "Missing colon ':' after the 'CAPI=2' directive"
                         )
+
+                    raise ValueError(
+                        f"Found {line!r} but expecting the 'CAPI=<version>' directive at the beginning"
                     )
-        except Exception:
-            error_msg = f"Unable to determine CAPI version from core file {core_file}"
-            logger.warning(error_msg)
+        except Exception as e:
+            logger.warning(
+                f"{e}. Unable to determine CAPI version from core file: {core_file!r}"
+            )
             return -1
 
     def _load_cores(self, library, ignored_dirs):

--- a/fusesoc/parser/coreparser.py
+++ b/fusesoc/parser/coreparser.py
@@ -46,7 +46,7 @@ class CoreParser:
                     self._set_additional_properties(v, val)
 
     def read(self, core_file, validate_core=True):
-        capi_data = utils.yaml_fread(core_file, self._resolve_env_vars, True)
+        capi_data = utils.yaml_fread(core_file, self._resolve_env_vars)
 
         if validate_core:
             self.validate(capi_data)

--- a/fusesoc/utils.py
+++ b/fusesoc/utils.py
@@ -155,10 +155,8 @@ def yaml_fwrite(filepath, content, preamble=""):
         f.write(yaml.dump(content, Dumper=YamlDumper, sort_keys=False))
 
 
-def yaml_fread(filepath, resolve_env_vars=False, remove_preamble=False):
+def yaml_fread(filepath, resolve_env_vars=False):
     with open(filepath) as f:
-        if remove_preamble:
-            f.readline()
         return yaml_read(f.read(), resolve_env_vars)
 
 

--- a/tests/test_capi2.py
+++ b/tests/test_capi2.py
@@ -692,6 +692,7 @@ def test_core2parser():
     assert parser.get_preamble() == "CAPI=2:"
 
     expected = {
+        "CAPI=2": None,
         "name": "::noadditionalproperties:0",
         "filesets": {
             "somename": {
@@ -731,6 +732,7 @@ def test_core2parser():
     assert parser.get_allow_additional_properties() is True
 
     expected = {
+        "CAPI=2": None,
         "name": "::withadditionalproperties:0",
         "filesets": {
             "somename": {
@@ -779,6 +781,7 @@ def test_inheritance():
     assert parser.get_preamble() == "CAPI=2:"
 
     expected = {
+        "CAPI=2": None,
         "name": "::inheritance:0",
         "filesets": {
             "fileset_a": {"files": ["1.txt", "2.txt", "3.txt"]},

--- a/tests/test_coremanager.py
+++ b/tests/test_coremanager.py
@@ -774,3 +774,167 @@ def test_find_cores_records_parse_errors(tmp_path):
     bad_file, msg = cm.parse_errors[0]
     assert bad_file.endswith("broken.core")
     assert "must be array" in msg
+
+
+def test_capi2_directive_relaxed_for_yaml(tmp_path):
+    """Support the YAML specification as-is without enforcing strange requirements."""
+    from textwrap import dedent
+
+    from fusesoc.config import Config
+    from fusesoc.coremanager import CoreManager
+    from fusesoc.librarymanager import Library
+
+    (tmp_path / "yaml_minimal.core").write_text(
+        dedent(
+            """
+            CAPI=2:
+            name: fusesoc:yaml:minimal:0
+            targets:
+              default: {}
+            """
+        )
+    )
+
+    (tmp_path / "yaml_full.core").write_text(
+        dedent(
+            """
+            %YAML 1.2
+            ---
+            # SPDX-FileCopyrightText: © 2026 John Doe <john.doe@fusesoc.com>
+            # SPDX-License-Identifier: BSD-2-Clause
+
+            CAPI=2:
+            name: fusesoc:yaml:full:0
+            targets:
+              default: {}
+            """
+        )
+    )
+
+    (tmp_path / "yaml_directives.core").write_text(
+        dedent(
+            """
+            %YAML 1.2
+            ---
+            CAPI=2:
+            name: fusesoc:yaml:directives:0
+            targets:
+              default: {}
+            """
+        )
+    )
+
+    (tmp_path / "yaml_start_document_indicator.core").write_text(
+        dedent(
+            """
+            ---
+            CAPI=2:
+            name: fusesoc:yaml:start_document_indicator:0
+            targets:
+              default: {}
+            """
+        )
+    )
+
+    (tmp_path / "yaml_comments.core").write_text(
+        dedent(
+            """
+            # SPDX-FileCopyrightText: © 2026 John Doe <john.doe@fusesoc.com>
+            # SPDX-License-Identifier: BSD-2-Clause
+                # Comment but with spaces
+            CAPI=2:
+            name: fusesoc:yaml:comments:0
+            targets:
+              default: {}
+            """
+        )
+    )
+
+    (tmp_path / "yaml_empty_lines.core").write_text(
+        dedent(
+            """
+
+
+            CAPI=2:
+            name: fusesoc:yaml:empty_lines:0
+            targets:
+              default: {}
+            """
+        )
+    )
+
+    cm = CoreManager(Config())
+    cm.add_library(Library("yaml", str(tmp_path)), [])
+
+    cores = {str(c) for c in cm.get_cores()}
+    assert "fusesoc:yaml:minimal:0" in cores
+    assert "fusesoc:yaml:full:0" in cores
+    assert "fusesoc:yaml:directives:0" in cores
+    assert "fusesoc:yaml:start_document_indicator:0" in cores
+    assert "fusesoc:yaml:comments:0" in cores
+    assert "fusesoc:yaml:empty_lines:0" in cores
+
+
+def test_capi2_directive_at_the_beginning(tmp_path, caplog):
+    """The ``CAPI=2:`` directive **MUST** be at the beginning of core files."""
+    from logging import WARNING
+    from textwrap import dedent
+
+    from fusesoc.config import Config
+    from fusesoc.coremanager import CoreManager
+    from fusesoc.librarymanager import Library
+
+    caplog.set_level(WARNING)
+
+    (tmp_path / "yaml.core").write_text(
+        dedent(
+            """
+            name: fusesoc:yaml:capi:2
+            CAPI=2:
+            targets:
+              default: {}
+            """
+        )
+    )
+
+    cm = CoreManager(Config())
+    cm.add_library(Library("yaml", str(tmp_path)), [])
+
+    cores = {str(c) for c in cm.get_cores()}
+    assert not cores
+    assert (
+        "Found 'name: fusesoc:yaml:capi:2' but expecting the 'CAPI=<version>' directive at the beginning"
+        in caplog.text
+    )
+
+
+def test_capi2_directive_required(tmp_path, caplog):
+    """The ``CAPI=2:`` directive is required in FuseSoC core files."""
+    from logging import WARNING
+    from textwrap import dedent
+
+    from fusesoc.config import Config
+    from fusesoc.coremanager import CoreManager
+    from fusesoc.librarymanager import Library
+
+    caplog.set_level(WARNING)
+
+    (tmp_path / "yaml.core").write_text(
+        dedent(
+            """
+            name: fusesoc:yaml:capi:2
+            targets:
+              default: {}
+            """
+        )
+    )
+
+    cm = CoreManager(Config())
+    cm.add_library(Library("yaml", str(tmp_path)), [])
+
+    cores = {str(c) for c in cm.get_cores()}
+    assert not cores
+    assert (
+        "Found 'name: fusesoc:yaml:capi:2' but expecting the 'CAPI=<version>' directive at the beginning"
+        in caplog.text
+    )


### PR DESCRIPTION
Closes https://github.com/olofk/fusesoc/issues/792

This will allow to follow the YAML specification as-is in FuseSoC core files. Originally, FuseSoC requires to have the `CAPI=2:` directive in the first line. This had many implications:

* Couldn't use YAML formatter tools on FuseSoC core files out-of-box. It requires non-default configuration settings
* Couldn't use YAML linter tools on FuseSoC core files out-of-box. It requires non-default configuration settings
* Couldn't use the YAML start document indicator `---` making some tools unhappy about that
* Couldn't use comments before the `CAPI=2:` directive like SPDX headers required by some licenses validation tools
* Couldn't use YAML directives like `%YAML 1.2` or `%TAG`
* Couldn't have empty lines
* The `CAPI=2` property was not part of the JSON schema validation

Now something like this is possible:

```yaml
%YAML 1.2
---
# SPDX-FileCopyrightText: © 2026 John Doe <john.doe@fusesoc.com>
# SPDX-License-Identifier: Apache-2.0

CAPI=2:
```

Still FuseSoC will require the `CAPI=2:` directive at the beginning of core files but at least users can use YAML directives `%`, YAML start document indicator `---`, comments, empty lines, YAML formatter/linter tools or licenses validation tools.

This PR is also including some unit tests.