### PR TITLE
feat(librarymanager): allow to use custom providers

### DIFF
--- a/fusesoc/coremanager.py
+++ b/fusesoc/coremanager.py
@@ -416,11 +416,7 @@ class CoreManager:
     def __init__(self, config, library_manager=None):
         self.config = config
         self.db = CoreDB()
-        self._lm = (
-            LibraryManager(config.library_root)
-            if library_manager is None
-            else library_manager
-        )
+        self._lm = LibraryManager() if library_manager is None else library_manager
         self.core2parser = Core2Parser(
             config.resolve_env_vars_early, config.allow_additional_properties
         )

--- a/fusesoc/fusesoc.py
+++ b/fusesoc/fusesoc.py
@@ -25,7 +25,7 @@ class Fusesoc:
     def __init__(self, config):
         self.config = config
 
-        self.lm = LibraryManager(config.library_root)
+        self.lm = LibraryManager()
         self.cm = CoreManager(self.config, library_manager=self.lm)
 
         self._register_libraries()
@@ -38,7 +38,7 @@ class Fusesoc:
                 self.add_library(library)
             except (RuntimeError, OSError):
                 try:
-                    temporary_lm = LibraryManager(self.config.library_root)
+                    temporary_lm = LibraryManager()
                     # try to initialize library
                     temporary_lm.add_library(library)
                     temporary_lm.update([library.name])

--- a/fusesoc/library.py
+++ b/fusesoc/library.py
@@ -1,0 +1,36 @@
+# Copyright FuseSoC contributors
+# Licensed under the 2-Clause BSD License, see LICENSE for details.
+# SPDX-License-Identifier: BSD-2-Clause
+
+
+class Library:
+    """FuseSoC library."""
+
+    def __init__(
+        self,
+        name: str,
+        location: str,
+        sync_type: str | None = None,
+        sync_uri: str | None = None,
+        sync_version: str | None = None,
+        auto_sync: bool = True,
+        sync_submodules: bool = False,
+    ) -> None:
+        """Create a new instance of FuseSoC library.
+
+        Args:
+            name: Name of library.
+            location: Path to library directory.
+            sync_type: Type of library synchronization.
+            sync_uri: URI to remote library.
+            sync_version: Version of library to synchronize during library updates.
+            auto_sync: If set to :data:`True` then it will automatically synchronize library.
+            sync_submodules: If set to :data:`True` then it will also clone/fetch git submodules.
+        """
+        self.name = name
+        self.location = location
+        self.sync_type = sync_type or "local"
+        self.sync_uri = sync_uri
+        self.sync_version = sync_version
+        self.auto_sync = auto_sync
+        self.sync_submodules = sync_submodules

--- a/fusesoc/librarymanager.py
+++ b/fusesoc/librarymanager.py
@@ -4,106 +4,125 @@
 
 import logging
 import os
+from collections.abc import Iterable
 
-from fusesoc.provider.provider import get_provider
+from fusesoc.library import Library
+from fusesoc.provider.provider import Provider, get_provider
 
 logger = logging.getLogger(__name__)
 
 
-class Library:
-    def __init__(
-        self,
-        name,
-        location,
-        sync_type=None,
-        sync_uri=None,
-        sync_version=None,
-        auto_sync=True,
-        sync_submodules=False,
-    ):
-        if sync_type and sync_type not in ["local", "git", "url"]:
-            raise ValueError(
-                "Library {} ({}) Invalid sync-type '{}'".format(
-                    name, location, sync_type
-                )
-            )
-
-        if sync_type in ["git", "url"]:
-            if not sync_uri:
-                raise ValueError(
-                    f"Library name ({location}) {sync_uri} must be set when using sync_type '{sync_type}'"
-                )
-
-        self.name = name
-        self.location = location
-        self.sync_type = sync_type or "local"
-        self.sync_uri = sync_uri
-        self.sync_version = sync_version
-        self.auto_sync = auto_sync
-        self.sync_submodules = sync_submodules
-
-    def update(self, force=False):
-        def lib(s):
-            return self.name + " : " + s
-
-        if self.sync_type == "local":
-            logger.info(lib("sync-type is local. Ignoring update"))
-            return
-
-        if not (self.auto_sync or force):
-            logger.info(lib("auto-sync disabled. Ignoring update"))
-            return
-
-        provider = get_provider(self.sync_type)
-
-        if not os.path.exists(self.location):
-            logger.info(lib(f"{self.location} does not exist. Trying a checkout"))
-            try:
-                provider.init_library(self)
-            except RuntimeError:
-                # Keep old behavior of logging a warning if there is a library
-                # in `fusesoc.conf`, but the directory does not exist for some
-                # reason and it could not be initialized.
-                logger.warning(lib(f"{self.location} does not exist. Ignoring update"))
-            return
-
-        try:
-            logger.info(lib("Updating..."))
-            provider.update_library(self)
-        except RuntimeError as e:
-            logger.error(lib("Failed to update library: " + str(e)))
-
-
 class LibraryManager:
-    def __init__(self, library_root):
-        self._libraries = []
-        self.library_root = library_root
+    """Manager to manage libraries. A library is an abstracted collection of FuseSoC cores."""
 
-    def add_library(self, library):
-        self._libraries.append(library)
+    def __init__(self) -> None:
+        """Create a new instance of library manager to manage libraries."""
+        self._libraries: dict[str, Library] = {}
+        """List of registered libraries."""
 
-    def get_library(self, value, key="name"):
-        for library in self._libraries:
-            if getattr(library, key) == value:
-                return library
+    def add_library(self, library: Library) -> None:
+        """Add library to manager.
 
-    def get_libraries(self):
-        return self._libraries
+        Args:
+            library: The library object.
+        """
+        self._libraries[library.name] = library
 
-    def update(self, library_names):
-        libraries = []
-        for name in library_names:
-            library = self.get_library(name)
-            if library:
-                libraries.append(library)
-            else:
-                logger.warning(f"Could not find library {name}")
+    def get_library(self, value: str, key: str | None = None) -> Library | None:
+        """Get library from manager.
 
+        Args:
+            name: Name of library.
+            key: Find library based on key.
+
+        Returns:
+            Library if found. Otherwise :data:`None` if not.
+        """
+        if key and key != "name":
+            # Slow path
+            for library in self._libraries.values():
+                if getattr(library, key, None) == value:
+                    return library
+
+            return None
+
+        # Fast path
+        return self._libraries.get(value)
+
+    def get_libraries(self) -> list[Library]:
+        """Get list of libraries.
+
+        Returns:
+            List of libraries.
+        """
+        return list(self._libraries.values())
+
+    def update(self, library_names: Iterable[str] | None = None) -> None:
+        """Update libraries.
+
+        Args:
+            library_names: List of libraries to update. If not provided or empty, update all libraries.
+        """
         if library_names:
-            force = True
-        else:
-            libraries = self._libraries
-            force = False
+            for name in library_names:
+                library: Library | None = self._libraries.get(name)
 
-        for library in libraries:
-            library.update(force)
+                if library:
+                    self._update_library(library, force=True)
+                else:
+                    logger.warning("%s : Could not find library", name)
+        else:
+            for library in self._libraries.values():
+                self._update_library(library, force=False)
+
+    def _update_library(self, library: Library, force: bool = False) -> None:
+        """Update library.
+
+        Args:
+            library: Library that will be updated.
+            force: Force library update.
+        """
+        if library.sync_type == "local":
+            logger.info("%s : sync-type is local. Ignoring update", library.name)
+            return
+
+        if not (library.auto_sync or force):
+            logger.info("%s : auto-sync disabled. Ignoring update", library.name)
+            return
+
+        provider: Provider = get_provider(library.sync_type)
+
+        if not library.location:
+            logger.error("%s : location to library was not specified", library.name)
+            return
+
+        if not library.sync_uri:
+            logger.error("%s : sync-uri to library was not specified", library.name)
+            return
+
+        if os.path.exists(library.location):
+            logger.info("%s : Updating...", library.name)
+            try:
+                provider.update_library(library)
+            except RuntimeError as e:
+                logger.error(
+                    "%s : %s Failed to update library: %s",
+                    library.name,
+                    library.location,
+                    e,
+                )
+        else:
+            logger.info(
+                "%s : %s does not exist. Trying to initialize library",
+                library.name,
+                library.location,
+            )
+            try:
+                provider.init_library(library)
+            except RuntimeError as e:
+                logger.error(
+                    "%s : %s Failed to initialize library: %s",
+                    library.name,
+                    library.location,
+                    e,
+                )

--- a/fusesoc/provider/git.py
+++ b/fusesoc/provider/git.py
@@ -5,6 +5,7 @@
 import logging
 import subprocess
 
+from fusesoc.library import Library
 from fusesoc.provider.provider import Provider
 from fusesoc.utils import Launcher
 
@@ -13,7 +14,7 @@ logger = logging.getLogger(__name__)
 
 class Git(Provider):
     @staticmethod
-    def _checkout_library_version(library):
+    def _checkout_library_version(library: Library) -> None:
         git_args = ["-C", library.location, "checkout", "-q", library.sync_version]
 
         if library.sync_version:
@@ -25,7 +26,7 @@ class Git(Provider):
             Launcher("git", git_args).run()
 
     @staticmethod
-    def _update_library_submodules(library):
+    def _update_library_submodules(library: Library) -> None:
         if library.sync_submodules:
             logger.info(f"Updating submodules for {library.name}")
             git_args = [
@@ -39,7 +40,7 @@ class Git(Provider):
             Launcher("git", git_args).run()
 
     @staticmethod
-    def init_library(library):
+    def init_library(library: Library) -> None:
         logger.info(f"Cloning library into {library.location}")
         git_args = ["clone", library.sync_uri, library.location]
         try:
@@ -50,7 +51,7 @@ class Git(Provider):
             raise RuntimeError(str(e))
 
     @staticmethod
-    def update_library(library):
+    def update_library(library: Library) -> None:
         download_option = "pull" if not library.sync_version else "fetch"
         git_args = ["-C", library.location, download_option]
         try:
@@ -60,7 +61,7 @@ class Git(Provider):
         except subprocess.CalledProcessError as e:
             raise RuntimeError(str(e))
 
-    def _checkout(self, local_dir):
+    def _checkout(self, local_dir: str) -> None:
         version = self.config.get("version", None)
 
         # TODO : Sanitize URL

--- a/fusesoc/provider/github.py
+++ b/fusesoc/provider/github.py
@@ -25,7 +25,7 @@ URL = "https://github.com/{user}/{repo}/archive/{version}.tar.gz"
 
 
 class Github(Provider):
-    def _checkout(self, local_dir):
+    def _checkout(self, local_dir: str) -> None:
         user = self.config.get("user")
         repo = self.config.get("repo")
 

--- a/fusesoc/provider/local.py
+++ b/fusesoc/provider/local.py
@@ -5,6 +5,7 @@
 import logging
 import os.path
 
+from fusesoc.library import Library
 from fusesoc.provider.provider import Provider
 
 logger = logging.getLogger(__name__)
@@ -12,7 +13,7 @@ logger = logging.getLogger(__name__)
 
 class Local(Provider):
     @staticmethod
-    def init_library(library):
+    def init_library(library: Library) -> None:
         if not os.path.isdir(library.location):
             logger.error(f"Local library at location '{library.location}' not found.")
             exit(1)
@@ -21,5 +22,5 @@ class Local(Provider):
         pass
 
     @staticmethod
-    def update_library(library):
+    def update_library(library: Library) -> None:
         pass

--- a/fusesoc/provider/provider.py
+++ b/fusesoc/provider/provider.py
@@ -8,6 +8,7 @@ import shutil
 import stat
 from importlib import import_module
 
+from fusesoc.library import Library
 from fusesoc.utils import Launcher
 
 logger = logging.getLogger(__name__)
@@ -83,3 +84,33 @@ class Provider:
             return "empty"
         else:
             return "downloaded"
+
+    @staticmethod
+    def init_library(library: Library) -> None:
+        """Initialize FuseSoC library.
+
+        .. note::
+
+           Method required by the FuseSoC library manager.
+
+        Args:
+            library: The FuseSoC library object.
+        """
+        raise NotImplementedError(
+            "The 'init_library' static method required by the FuseSoC library manager is not implemented by this provider"
+        )
+
+    @staticmethod
+    def update_library(library: Library) -> None:
+        """Update FuseSoC library.
+
+        .. note::
+
+           Method required by the FuseSoC library manager.
+
+        Args:
+            library: The FuseSoC library object.
+        """
+        raise NotImplementedError(
+            "The 'update_library' static method required by the FuseSoC library manager is not implemented by this provider"
+        )

--- a/fusesoc/provider/url.py
+++ b/fusesoc/provider/url.py
@@ -17,6 +17,7 @@ else:
     from urllib2 import URLError
     from urllib2 import HTTPError
 
+from fusesoc.library import Library
 from fusesoc.provider.provider import Provider
 
 logger = logging.getLogger(__name__)
@@ -26,7 +27,7 @@ _HAS_TAR_FILTER = hasattr(tarfile, "tar_filter")  # Requires Python 3.12
 
 class Url(Provider):
     @staticmethod
-    def init_library(library):
+    def init_library(library: Library) -> None:
         try:
             logger.info(f"Downloading library from {library.sync_uri}...")
             Url._download(library.sync_uri, library.location, "zip")
@@ -35,7 +36,7 @@ class Url(Provider):
             raise RuntimeError(str(e))
 
     @staticmethod
-    def update_library(library):
+    def update_library(library: Library) -> None:
         try:
             Url._download(library.sync_uri, library.location, "zip")
         except Exception as e:

--- a/tests/test_libraries.py
+++ b/tests/test_libraries.py
@@ -241,6 +241,8 @@ auto-sync = true
         with caplog.at_level(logging.INFO):
             fs.update_libraries([])
 
-        assert "vlog_tb_utils does not exist. Trying a checkout" in caplog.text
+        assert (
+            "vlog_tb_utils does not exist. Trying to initialize library" in caplog.text
+        )
         assert f"Cloning library into {library}/vlog_tb_utils" in caplog.text
         assert "Updating..." in caplog.text


### PR DESCRIPTION
Closes https://github.com/olofk/fusesoc/issues/797

This PR allows to use custom providers to manage FuseSoC libraries.

Additionally:

* Moved the `Library` class to own `fusesoc/library.py` module. This is required to avoid circular imports between provider and library manager. The implementation of the `Library.update()` method was moved to the library manager to break the circular import of the `Library` class
* Added missing type annotations in providers, library and library manager
* Added missing docstrings in providers, library and library manager
* The library manager is now abstracted from providers (except for the `local` provider). Replaced strings like `checkout` that are git specific with `update/initialize`
* Removed the `library_root` attribute from the library manager. It was never used anywhere. Dead attribute
* Optimized the `LibraryManager.get_library()` method for fast lookup by using dictionary instead of list
* Using lazy evaluation in logging. Reason: https://news.ycombinator.com/item?id=44600537
