### PR TITLE
Update pre-commit pyupgrade and black versions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,7 +20,7 @@ repos:
         # Test golden references
         exclude: ^tests/(.+\.(info|patch)|test_provider/.+\.v)
   - repo: https://github.com/asottile/pyupgrade
-    rev: v2.7.4
+    rev: v3.21.2
     hooks:
       - id: pyupgrade
         # for now don't force to change from %-operator to {}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,7 +31,7 @@ repos:
       - id: isort
         args: ["--profile", "black", "--filter-files"]
   - repo: https://github.com/psf/black
-    rev: 22.3.0
+    rev: 24.10.0
     hooks:
       - id: black
   - repo: https://github.com/astral-sh/ruff-pre-commit

--- a/fusesoc/capi2/core.py
+++ b/fusesoc/capi2/core.py
@@ -517,9 +517,11 @@ Targets:
             for name in sorted(cd_targets):
                 targets += "{} : {}\n".format(
                     name.ljust(maxlen),
-                    cd_targets[name].description
-                    if "description" in cd_targets[name].description
-                    else "<No description>",
+                    (
+                        cd_targets[name].description
+                        if "description" in cd_targets[name].description
+                        else "<No description>"
+                    ),
                 )
         else:
             targets = "<No targets>"

--- a/fusesoc/capi2/core.py
+++ b/fusesoc/capi2/core.py
@@ -85,7 +85,7 @@ class CoreInterface:
             src_files += [
                 f for f in v["src_files"] + v["inc_files"]
             ]  # FIXME include files
-        self._debug("Exporting {}".format(str(src_files)))
+        self._debug(f"Exporting {str(src_files)}")
 
         filesets = self.get_data(flags).filesets
 
@@ -181,7 +181,7 @@ class CoreInterface:
         return list(target.filters) if (target := self.get_target(flags)) else []
 
     def get_flow(self, flags):
-        self._debug("Getting flow for flags {}".format(str(flags)))
+        self._debug(f"Getting flow for flags {str(flags)}")
         flow = None
         if flags.get("flow"):
             flow = flags["flow"]
@@ -199,7 +199,7 @@ class CoreInterface:
         return flow
 
     def get_scripts(self, files_root, flags):
-        self._debug("Getting hooks for flags '{}'".format(str(flags)))
+        self._debug(f"Getting hooks for flags '{str(flags)}'")
         hooks = {}
         for hook, scripts in self._get_script_names(flags).items():
             hooks[hook] = []
@@ -219,7 +219,7 @@ class CoreInterface:
     def get_tool_options(self, flags):
         _flags = flags.copy()
 
-        self._debug("Getting tool options for flags {}".format(str(_flags)))
+        self._debug(f"Getting tool options for flags {str(_flags)}")
 
         target_name, target = self._get_target(_flags)
         tool = flags["tool"]
@@ -239,7 +239,7 @@ class CoreInterface:
     def get_flow_options(self, flags):
         _flags = flags.copy()
 
-        self._debug("Getting flow options for flags {}".format(str(_flags)))
+        self._debug(f"Getting flow options for flags {str(_flags)}")
         target_name, target = self._get_target(_flags)
 
         if "flow_options" in target:
@@ -251,7 +251,7 @@ class CoreInterface:
 
     def get_depends(self, flags):  # Add use flags?
         depends = []
-        self._debug("Getting dependencies for flags {}".format(str(flags)))
+        self._debug(f"Getting dependencies for flags {str(flags)}")
         for fs in self._get_filesets(flags):
             depends += [Vlnv(d) for d in fs["depend"]]
         return depends
@@ -352,7 +352,7 @@ class CoreInterface:
 
             return parsed_param
 
-        self._debug("Getting parameters for flags '{}'".format(str(flags)))
+        self._debug(f"Getting parameters for flags '{str(flags)}'")
         target = self.get_target(flags)
         parameters = {}
 
@@ -406,7 +406,7 @@ class CoreInterface:
     def get_toplevel(self, flags):
         _flags = flags.copy()
         _flags["is_toplevel"] = True  # FIXME: Is this correct?
-        self._debug("Getting toplevel for flags {}".format(str(_flags)))
+        self._debug(f"Getting toplevel for flags {str(_flags)}")
         target_name, target = self._get_target(_flags)
 
         if "toplevel" in target:
@@ -418,7 +418,7 @@ class CoreInterface:
             raise SyntaxError(s.format(self.name, target_name))
 
     def get_ttptttg(self, flags):
-        self._debug("Getting ttptttg for flags {}".format(str(flags)))
+        self._debug(f"Getting ttptttg for flags {str(flags)}")
         target_name, target = self._get_target(flags)
         ttptttg = []
 
@@ -487,7 +487,7 @@ class CoreInterface:
         self._debug(f"Getting VPI libraries for flags {flags}")
         vpi = []
         _vpi = self._get_vpi(flags)
-        self._debug(" Matched VPI libraries {}".format([v for v in _vpi]))
+        self._debug(f" Matched VPI libraries {[v for v in _vpi]}")
         for k, v in sorted(_vpi.items()):
             vpi.append(
                 {
@@ -567,10 +567,10 @@ Targets:
                 self.patch(self.files_root)
 
     def _debug(self, msg):
-        logger.debug("{} : {}".format(str(self.name), msg))
+        logger.debug(f"{str(self.name)} : {msg}")
 
     def _get_target(self, flags: Flags):
-        self._debug(" Resolving target for flags '{}'".format(str(flags)))
+        self._debug(f" Resolving target for flags '{str(flags)}'")
 
         cd_target = self.get_target(flags)
         target_name = get_target_name(flags)
@@ -583,7 +583,7 @@ Targets:
             return target_name, {}
 
     def _get_filesets(self, flags):
-        self._debug("Getting filesets for flags '{}'".format(str(flags)))
+        self._debug(f"Getting filesets for flags '{str(flags)}'")
         target_name, target = self._get_target(flags)
         if not target:
             return []

--- a/fusesoc/coremanager.py
+++ b/fusesoc/coremanager.py
@@ -71,7 +71,7 @@ class CoreDB:
         package_names = []
         for virtual in virtuals:
             for simple in virtual.simpleVLNVs():
-                package_names.append("{}".format(self._package_name(simple)))
+                package_names.append(f"{self._package_name(simple)}")
         return ", ".join(package_names)
 
     def add(self, core, library):
@@ -571,7 +571,7 @@ class CoreManager:
         )
         resolved_core = self.db.find(core)
         deps = self.db.solve(resolved_core.name, flags)
-        logger.debug(" Resolved core to {}".format(str(resolved_core.name)))
+        logger.debug(f" Resolved core to {str(resolved_core.name)}")
         logger.debug(" with dependencies " + ", ".join([str(c.name) for c in deps]))
         return deps
 

--- a/fusesoc/edalizer.py
+++ b/fusesoc/edalizer.py
@@ -215,7 +215,7 @@ class Edalizer:
         for core in self.cores:
             snippet = {}
 
-            logger.debug("Collecting EDAM parameters from {}".format(str(core.name)))
+            logger.debug(f"Collecting EDAM parameters from {str(core.name)}")
             _flags = self._core_flags(core)
 
             # Extract direct dependencies
@@ -382,7 +382,7 @@ class Edalizer:
                     )
                 except KeyError as e:
                     raise RuntimeError(
-                        "Invalid data type {} for parameter '{}'".format(str(e), name)
+                        f"Invalid data type {str(e)} for parameter '{name}'"
                     )
                 param_type_map[name.replace("-", "_")] = _paramtype
             else:

--- a/fusesoc/fusesoc.py
+++ b/fusesoc/fusesoc.py
@@ -179,7 +179,7 @@ class Fusesoc:
         except SyntaxError as e:
             raise RuntimeError(e.msg)
         except RuntimeError as e:
-            raise RuntimeError("Setup failed : {}".format(str(e)))
+            raise RuntimeError(f"Setup failed : {str(e)}")
         except DependencyError as e:
             raise RuntimeError("Failed to resolve dependencies. " + e.msg)
 

--- a/fusesoc/main.py
+++ b/fusesoc/main.py
@@ -558,17 +558,17 @@ def get_parser():
     parser_core_show = core_subparsers.add_parser(
         "show", help="Show information about a core"
     )
-    parser_core_show.add_argument(
-        "core", help="Name of the core to show"
-    ).completer = CoreCompleter()
+    parser_core_show.add_argument("core", help="Name of the core to show").completer = (
+        CoreCompleter()
+    )
     parser_core_show.set_defaults(func=core_info)
 
     parser_core_sign = core_subparsers.add_parser(
         "sign", help="Create user signature for a core"
     )
-    parser_core_sign.add_argument(
-        "core", help="Name of the core to sign"
-    ).completer = CoreCompleter()
+    parser_core_sign.add_argument("core", help="Name of the core to sign").completer = (
+        CoreCompleter()
+    )
     parser_core_sign.add_argument("keyfile", help="File containing ssh private key")
     parser_core_sign.set_defaults(func=core_sign)
 

--- a/fusesoc/main.py
+++ b/fusesoc/main.py
@@ -111,7 +111,7 @@ def fetch(fs, args):
     try:
         core.setup()
     except RuntimeError as e:
-        logger.error("Failed to fetch '{}': {}".format(core.name, str(e)))
+        logger.error(f"Failed to fetch '{core.name}': {str(e)}")
         exit(1)
 
 
@@ -419,14 +419,14 @@ def run(fs, args):
         try:
             backend.build()
         except RuntimeError as e:
-            logger.error("Failed to build {} : {}".format(str(core.name), str(e)))
+            logger.error(f"Failed to build {str(core.name)} : {str(e)}")
             exit(1)
 
     if do_run:
         try:
             backend.run()
         except RuntimeError as e:
-            logger.error("Failed to run {} : {}".format(str(core.name), str(e)))
+            logger.error(f"Failed to run {str(core.name)} : {str(e)}")
             exit(1)
 
 

--- a/fusesoc/provider/github.py
+++ b/fusesoc/provider/github.py
@@ -4,22 +4,15 @@
 
 import logging
 import os.path
-import sys
 import tarfile
+import urllib.request as urllib
+from urllib.error import URLError
 
 from fusesoc.provider.provider import Provider
 
 _HAS_TAR_FILTER = hasattr(tarfile, "tar_filter")  # Requires Python 3.12
 
 logger = logging.getLogger(__name__)
-
-if sys.version_info[0] >= 3:
-    import urllib.request as urllib
-    from urllib.error import URLError
-else:
-    import urllib
-
-    from urllib2 import URLError
 
 URL = "https://github.com/{user}/{repo}/archive/{version}.tar.gz"
 

--- a/fusesoc/provider/url.py
+++ b/fusesoc/provider/url.py
@@ -7,15 +7,9 @@ import os.path
 import shutil
 import sys
 import tarfile
+import urllib.request as urllib
 import zipfile
-
-if sys.version_info[0] >= 3:
-    import urllib.request as urllib
-    from urllib.error import HTTPError, URLError
-else:
-    import urllib
-    from urllib2 import URLError
-    from urllib2 import HTTPError
+from urllib.error import HTTPError, URLError
 
 from fusesoc.library import Library
 from fusesoc.provider.provider import Provider

--- a/tests/test_provider.py
+++ b/tests/test_provider.py
@@ -55,9 +55,10 @@ def test_github_provider():
         assert os.path.isfile(os.path.join(core.files_root, f))
         ref_dir = os.path.join(os.path.dirname(__file__), __name__)
         f = "vlog_functions.v"
-    with open(os.path.join(ref_dir, f)) as fref, open(
-        os.path.join(core.files_root, f)
-    ) as fgen:
+    with (
+        open(os.path.join(ref_dir, f)) as fref,
+        open(os.path.join(core.files_root, f)) as fgen,
+    ):
         assert fref.read() == fgen.read(), f
 
 


### PR DESCRIPTION
* Update pre-commit pyupgrade to version 3.21.2 (from 2.7.4)
* Convert .format() calls to f-strings (done by pyupgrade)
* Drop Python 2 urllib compatability fallback (2.7 has been EOL since 2020-01-01)
* Update pre-commit black to version 24.10.0 (from 22.3.0)
* Reformat with updated black version