### PR TITLE
Fix "fusesoc core show <core>" not showing target descriptions

### DIFF
--- a/fusesoc/capi2/core.py
+++ b/fusesoc/capi2/core.py
@@ -517,11 +517,7 @@ Targets:
             for name in sorted(cd_targets):
                 targets += "{} : {}\n".format(
                     name.ljust(maxlen),
-                    (
-                        cd_targets[name].description
-                        if "description" in cd_targets[name].description
-                        else "<No description>"
-                    ),
+                    cd_targets[name].description or "<No description>",
                 )
         else:
             targets = "<No targets>"


### PR DESCRIPTION
Fix for issue #810.

Without fix:

```
>fusesoc core show fifo
CORE INFO
Name:        ::fifo:1.3-r1
Description: Generic FIFO
Core root:   /my/core/root/fifo 
Core file:   fifo-1.3-r1.core
Signature:   Not signed

Targets:
default            : <No description>
dual_clock_fifo_tb : <No description>
fifo_fwft_tb       : <No description>
fifo_tb            : <No description>

>

```
With the fix in this PR:

```
>fusesoc core show fifo
CORE INFO
Name:        ::fifo:1.3-r1
Description: Generic FIFO
Core root:   /my/core/root/fifo
Core file:   fifo-1.3-r1.core
Signature:   Not signed

Targets:
default            : <No description>
dual_clock_fifo_tb : Testbench for dual clock FIFO
fifo_fwft_tb       : Testbench for First Word Fall Through FIFO
fifo_tb            : Testbench single clock FIFO

>
```