### PR TITLE
add devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,72 @@
+# fusesoc dev container
+FROM mcr.microsoft.com/devcontainers/python:3.12
+
+# extraneous package manifest:
+#   subversion
+#   openssh-client
+#   iverilog
+#   verilator
+#   make
+RUN apt-get update \
+    && export DEBIAN_FRONTEND=noninteractive \
+    && apt-get install -y --no-install-recommends \
+        subversion \
+        openssh-client \
+        iverilog \
+        verilator \
+        make \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+# slang-server: (https://github.com/hudson-trading/slang-server)
+# bump version as necessary
+ARG SLANG_SERVER_VERSION=v0.3.0
+RUN set -eu; \
+    case "$(uname -m)" in \
+        x86_64)  asset=slang-server-linux-x64 ;; \
+        aarch64) asset=slang-server-linux-arm64 ;; \
+        *) echo "unsupported architecture: $(uname -m)" >&2; exit 1 ;; \
+    esac; \
+    url="https://github.com/hudson-trading/slang-server/releases/download/${SLANG_SERVER_VERSION}/${asset}.tar.gz"; \
+    curl -fsSL "$url" -o /tmp/slang-server.tar.gz; \
+    tar -xzf /tmp/slang-server.tar.gz -C /usr/local/bin ./slang-server; \
+    chmod 0755 /usr/local/bin/slang-server; \
+    rm /tmp/slang-server.tar.gz; \
+    slang-server --version
+
+# Trust GitHub's SSH host keys system-wide so that git operations over SSH
+# (e.g. pushing to a fork) don't stop at an interactive "authenticity of host"
+# prompt on first use. The keys themselves are never copied into the image:
+# VS Code forwards the host's ssh-agent into the container (see
+# devcontainer.json), so private keys stay on the host.
+RUN mkdir -p /etc/ssh \
+    && ssh-keyscan -t rsa,ecdsa,ed25519 github.com >> /etc/ssh/ssh_known_hosts
+
+# The workspace is bind-mounted from the host and its top-level directory can
+# show up as owned by a different uid than the "vscode" user (this is the case
+# with Docker Desktop on macOS). Git then refuses to operate on it with
+# "detected dubious ownership", which also breaks pre-commit. Mark all
+# directories as safe; inside a single-user dev container this is harmless.
+RUN git config --system --add safe.directory '*'
+
+# Keep pip quiet and skip the version nag inside the container.
+ENV PIP_DISABLE_PIP_VERSION_CHECK=1 \
+    PIP_NO_CACHE_DIR=1
+
+# The base image ships a pytest installed with pipx into an isolated venv, and
+# puts that venv's bin dir ahead of /usr/local/bin on PATH (via
+# /etc/profile.d/00-restore-env.sh). That pytest cannot import fusesoc or its
+# dependencies. Remove it so that a bare "pytest" resolves to the one
+# installed from dev-requirements.txt below, which shares the interpreter
+# fusesoc is installed into.
+RUN PIPX_HOME=/usr/local/py-utils PIPX_BIN_DIR=/usr/local/py-utils/bin \
+    pipx uninstall pytest
+
+# Install the Python packages needed to develop fusesoc (pre-commit, pytest,
+# tox) at image build time so they are available immediately and don't have to
+# be re-downloaded on every container creation. Only the requirements file is
+# copied in; the source tree itself is bind-mounted by VS Code and installed in
+# editable mode by postCreateCommand (see devcontainer.json).
+COPY dev-requirements.txt /tmp/dev-requirements.txt
+RUN pip install -r /tmp/dev-requirements.txt \
+    && rm /tmp/dev-requirements.txt

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,73 @@
+{
+  "name": "FuseSoC",
+  "build": {
+    "dockerfile": "Dockerfile",
+    "context": ".." // always build from root
+  },
+
+  // The host checkout may contain a macOS/Windows-built .venv and .tox
+  // so we shadow them
+  "mounts": [
+    "source=fusesoc-venv,target=${containerWorkspaceFolder}/.venv,type=volume",
+    "source=fusesoc-tox,target=${containerWorkspaceFolder}/.tox,type=volume"
+  ],
+
+  // load your key into ssh agent w/
+  //
+  //     ssh-add --apple-use-keychain ~/.ssh/id_ed25519
+  "containerEnv": {
+    // allow to run pytest without tox
+    "MODEL_TECH": "dummy_value"
+  },
+
+  // fusesoc is installed with "pip install --user" in ~/.local/bin.
+  "remoteEnv": {
+    "PATH": "/home/vscode/.local/bin:${containerEnv:PATH}"
+  },
+
+  // see script for details
+  "postCreateCommand": "bash .devcontainer/post-create.sh",
+
+  "remoteUser": "vscode",
+
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "ms-python.python",
+        "ms-python.vscode-pylance",
+        "ms-python.debugpy",
+        "ms-python.black-formatter",
+        "ms-python.isort",
+        "charliermarsh.ruff",
+        "ms-python.mypy-type-checker",
+        "astral-sh.ty",
+        "tamasfe.even-better-toml",
+        "editorconfig.editorconfig",
+        "redhat.vscode-yaml",
+        "lextudio.restructuredtext",
+        "Hudson-River-Trading.vscode-slang"
+      ],
+      "settings": {
+        "python.defaultInterpreterPath": "/usr/local/bin/python",
+        "python.testing.pytestEnabled": true,
+        "python.testing.unittestEnabled": false,
+        "python.testing.pytestArgs": ["tests"],
+        "[python]": {
+          "editor.defaultFormatter": "ms-python.black-formatter",
+          "editor.formatOnSave": true,
+          "editor.codeActionsOnSave": {
+            "source.organizeImports": "explicit"
+          }
+        },
+        "isort.args": ["--profile", "black"],
+        "mypy-type-checker.args": ["--config-file=pyproject.toml"],
+        "slang.path": "/usr/local/bin/slang-server",
+        "files.associations": {
+          "*.core": "yaml"
+        },
+        "files.eol": "\n",
+        "files.insertFinalNewline": true
+      }
+    }
+  }
+}

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# .venv and .tox are named volumes. Give them to user instead of roo
+sudo chown vscode:vscode .venv .tox
+
+# The system site-packages directory is root-owned, so install fusesoc into the
+# user site
+pip install --user -e .
+
+# Build the pre-commit hook environments (black, ruff, mypy, ty, ...)
+pre-commit install-hooks
+
+# Only write the git hook file if the checkout doesn't already have one.
+if [ ! -e .git/hooks/pre-commit ]; then
+    pre-commit install
+fi
+
+# Some tests need an initialized FuseSoC library to be present (see tox.ini).
+fusesoc library add --global fusesoc_cores https://github.com/fusesoc/fusesoc-cores


### PR DESCRIPTION
add a development container & corresponding vscode instructions for fusesoc development. Based off of python3.12 devcontainer, also installs pre-commit automatically using a post-run script to save time on first commit to make it as seamless as possible.